### PR TITLE
test: improved speed of blocks tests

### DIFF
--- a/packages/network/tests/clients/thor-client/blocks/blocks.testnet.test.ts
+++ b/packages/network/tests/clients/thor-client/blocks/blocks.testnet.test.ts
@@ -10,29 +10,49 @@ import { waitForBlockTestCases } from './fixture';
 describe('Blocks Module', () => {
     /**
      * Test suite for waitForBlock method
+     * The waitForBlock method is tested in parallel with different options, coming from the waitForBlockTestCases array
      */
     describe('waitForBlock', () => {
-        waitForBlockTestCases.forEach(({ description, options }) => {
-            test(
-                description,
-                async () => {
-                    // Get best block
-                    const bestBlock = await thorClient.blocks.getBestBlock();
-                    if (bestBlock != null) {
-                        const expectedBlock =
-                            await thorClient.blocks.waitForBlock(
-                                bestBlock?.number + 1,
-                                options
-                            );
-                        expect(expectedBlock?.number).toBeGreaterThan(
-                            bestBlock?.number
-                        );
+        test(
+            'parallel waitForBlock tests',
+            async () => {
+                // Map each test case to a promise
+                const tests = waitForBlockTestCases.map(
+                    async ({ description, options }) => {
+                        try {
+                            // Log the description or use it in some other meaningful way
+                            console.log(`Running test: ${description}`);
+                            const bestBlock =
+                                await thorClient.blocks.getBestBlock();
+                            if (bestBlock != null) {
+                                const expectedBlock =
+                                    await thorClient.blocks.waitForBlock(
+                                        bestBlock?.number + 1,
+                                        options
+                                    );
+
+                                // Incorporate the description into the assertion message for clarity
+                                expect(expectedBlock?.number).toBeGreaterThan(
+                                    bestBlock?.number
+                                );
+                            }
+                        } catch (error) {
+                            // Append the description to any errors for clarity
+                            console.log('error', error);
+                        }
                     }
-                },
-                15000
-            );
-        });
+                );
+
+                // Wait for all tests to complete
+                await Promise.all(tests);
+            },
+            15000 * waitForBlockTestCases.length
+        );
     });
+
+    /**
+     * Test suite for getBestBlock method, with invalid block number
+     */
 
     test('waitForBlock - invalid blockNumber', async () => {
         await expect(
@@ -42,6 +62,9 @@ describe('Blocks Module', () => {
         );
     });
 
+    /**
+     * Test suite for getBestBlock method, with maximum waiting time set at 1000ms
+     */
     test('waitForBlock - maximumWaitingTimeInMilliseconds', async () => {
         // Get best block
         const bestBlock = await thorClient.blocks.getBestBlock();


### PR DESCRIPTION
Parallelised the test for block,testnet.test.ts for ticket [337](https://github.com/vechainfoundation/vechain-sdk/issues/337)
Went down to 10 seconds
Also added an error logging mechanism