### PR TITLE
test: improved blocks test speed

### DIFF
--- a/packages/network/tests/thor-client/blocks/blocks.testnet.test.ts
+++ b/packages/network/tests/thor-client/blocks/blocks.testnet.test.ts
@@ -24,8 +24,6 @@ describe('Blocks Module', () => {
                 const tests = waitForBlockTestCases.map(
                     async ({ description, options }) => {
                         try {
-                            // Log the description or use it in some other meaningful way
-                            //  console.log(`Running test: ${description}`);
                             const bestBlock =
                                 await thorClient.blocks.getBestBlock();
                             if (bestBlock != null) {


### PR DESCRIPTION
Improved test speed for blocks.test at ticket [337](https://github.com/vechainfoundation/vechain-sdk/issues/337)

@vechainfoundation/vechain-sdk-network:test: PASS tests/thor-client/blocks/blocks.testnet.test.ts (18.778 s)
