### PR TITLE
fix: mock some tests and minimize logs call

### DIFF
--- a/packages/provider/tests/rpc-mapper/methods/eth_getLogs/eth_getLogs.mock.solo.test.ts
+++ b/packages/provider/tests/rpc-mapper/methods/eth_getLogs/eth_getLogs.mock.solo.test.ts
@@ -4,12 +4,12 @@ import { ThorClient } from '@vechain/sdk-network';
 import { soloNetwork } from '../../../fixture';
 import { type LogsRPC } from '../../../../src/utils/formatter/logs';
 import { ProviderRpcError } from '@vechain/sdk-errors';
-import { logsFixture } from './fixture';
+import { logsFixture, mockLogsFixture } from './fixture';
 
 /**
  * RPC Mapper integration tests for 'eth_getLogs' method
  *
- * @group integration/rpc-mapper/methods/eth_getLogs
+ * @group integration/rpc-mapper/methods/eth_getLogs-mock
  */
 describe('RPC Mapper - eth_getLogs method tests', () => {
     /**
@@ -26,6 +26,31 @@ describe('RPC Mapper - eth_getLogs method tests', () => {
     });
 
     /**
+     * eth_getLogs RPC call tests - Positive cases
+     */
+    describe('eth_getLogs - Positive cases', () => {
+        /**
+         * Positive cases. Should be able to get logs
+         */
+        mockLogsFixture.forEach((fixture, index) => {
+            test(`eth_getLogs - Should be able to get logs test - ${index + 1}`, async () => {
+                // Mock the getGenesisBlock method to return null
+                jest.spyOn(
+                    thorClient.logs,
+                    'filterEventLogs'
+                ).mockResolvedValue([]);
+
+                // Call RPC method
+                const logs = (await RPCMethodsMap(thorClient)[
+                    RPC_METHODS.eth_getLogs
+                ]([fixture.input])) as LogsRPC[];
+
+                expect(logs.slice(0, 4)).toStrictEqual(fixture.expected);
+            }, 6000);
+        });
+    });
+
+    /**
      * eth_getLogs RPC call tests - Negative cases
      */
     describe('eth_getLogs - Negative cases', () => {
@@ -33,7 +58,7 @@ describe('RPC Mapper - eth_getLogs method tests', () => {
          * Negative case 2 - Should throw an error for invalid input if request is invalid
          */
         test('eth_getLogs - Should throw error if request is invalid', async () => {
-            // Mock the getGenesisBlock method to return null
+            // Mock the filterEventLogs method to throw error
             jest.spyOn(thorClient.logs, 'filterEventLogs').mockRejectedValue(
                 new Error()
             );

--- a/packages/provider/tests/rpc-mapper/methods/eth_getLogs/eth_getLogs.testnet.test.ts
+++ b/packages/provider/tests/rpc-mapper/methods/eth_getLogs/eth_getLogs.testnet.test.ts
@@ -33,13 +33,13 @@ describe('RPC Mapper - eth_getLogs method tests', () => {
          * Positive cases. Should be able to get logs
          */
         logsFixture.forEach((fixture, index) => {
-            test(`eth_getLogs - Should be able to get logs - ${index} with input: ${JSON.stringify(fixture.input)}`, async () => {
+            test(`eth_getLogs - Should be able to get logs test - ${index + 1}`, async () => {
                 // Call RPC method
                 const logs = (await RPCMethodsMap(thorClient)[
                     RPC_METHODS.eth_getLogs
                 ]([fixture.input])) as LogsRPC[];
 
-                expect(logs.slice(0, 4)).toStrictEqual(fixture.expectedSliced);
+                expect(logs.slice(0, 4)).toStrictEqual(fixture.expected);
             }, 6000);
         });
     });

--- a/packages/provider/tests/rpc-mapper/methods/eth_getLogs/fixture.ts
+++ b/packages/provider/tests/rpc-mapper/methods/eth_getLogs/fixture.ts
@@ -19,7 +19,7 @@ const logsFixture = [
                 '0x0000000000000000000000005034aa590125b64023a0262112b98d72e3c8e40e'
             ]
         },
-        expectedSliced: [
+        expected: [
             {
                 transactionHash:
                     '0x0ee8df3a9de6787ec0848ea8951ed8899bb053b6b4af167228dd7c0c012f5346',
@@ -89,8 +89,13 @@ const logsFixture = [
                 transactionIndex: '0x0'
             }
         ]
-    },
+    }
+];
 
+/**
+ * Fixtures for eth_getLogs mocked positive cases
+ */
+const mockLogsFixture = [
     // To block not defined (latest block as default)
     {
         input: {
@@ -106,7 +111,7 @@ const logsFixture = [
             fromBlock: Hex0x.of(0),
             toBlock: Hex0x.of(1)
         },
-        expectedSliced: []
+        expected: []
     },
 
     // From block and to not defined (latest block as default)
@@ -124,7 +129,7 @@ const logsFixture = [
             fromBlock: Hex0x.of(0),
             toBlock: Hex0x.of(1)
         },
-        expectedSliced: []
+        expected: []
     },
 
     // No topics defined, only addresses
@@ -137,7 +142,7 @@ const logsFixture = [
             fromBlock: Hex0x.of(0),
             toBlock: Hex0x.of(1)
         },
-        expectedSliced: []
+        expected: []
     },
 
     // No addresses defined, only topics
@@ -149,7 +154,7 @@ const logsFixture = [
             fromBlock: Hex0x.of(0),
             toBlock: Hex0x.of(1)
         },
-        expectedSliced: []
+        expected: []
     },
 
     // fromBlock and toBlock not defined (latest block as default)
@@ -157,8 +162,8 @@ const logsFixture = [
         input: {
             address: '0x0000000000000000000000000000456e65726779'
         },
-        expectedSliced: []
+        expected: []
     }
 ];
 
-export { logsFixture };
+export { logsFixture, mockLogsFixture };


### PR DESCRIPTION
# Description

Probably last solutions for eth_getLogs test failing.

 - [x] Mocked tests to have 100% coverage
 - [x] Reduce amount go eth_getLogs calls