### PR TITLE
Fix formatTransactionReceiptToRPCStandard()

### DIFF
--- a/packages/provider/src/utils/formatter/transactions/formatter.ts
+++ b/packages/provider/src/utils/formatter/transactions/formatter.ts
@@ -154,22 +154,22 @@ function formatTransactionReceiptToRPCStandard(
 
     const logIndexes: string[] = filledLogIndexes.map((i) => Quantity.of(i));
 
-    const logs: TransactionReceiptLogsRPC[] =
-        receipt.outputs.length > 0 && receipt.outputs[0].events.length > 0
-            ? receipt.outputs[0].events.map((event, index) => {
-                  return {
-                      blockHash: receipt.meta.blockID,
-                      blockNumber: Quantity.of(receipt.meta.blockNumber),
-                      transactionHash: receipt.meta.txID as string,
-                      address: event.address,
-                      topics: event.topics.map((topic) => topic),
-                      data: event.data,
-                      removed: false,
-                      transactionIndex: Quantity.of(transactionIndex),
-                      logIndex: logIndexes[index]
-                  };
-              })
-            : [];
+    const logs: TransactionReceiptLogsRPC[] = [];
+    receipt.outputs.forEach((output) => {
+        output.events.forEach((event, index) => {
+            logs.push({
+                blockHash: receipt.meta.blockID,
+                blockNumber: Quantity.of(receipt.meta.blockNumber),
+                transactionHash: receipt.meta.txID as string,
+                address: event.address,
+                topics: event.topics.map((topic) => topic),
+                data: event.data,
+                removed: false,
+                transactionIndex: Quantity.of(transactionIndex),
+                logIndex: logIndexes[index]
+            });
+        });
+    });
 
     return {
         blockHash: receipt.meta.blockID,

--- a/packages/provider/tests/rpc-mapper/methods/eth_getTransactionReceipt/fixture.ts
+++ b/packages/provider/tests/rpc-mapper/methods/eth_getTransactionReceipt/fixture.ts
@@ -116,7 +116,99 @@ const getReceiptCorrectCasesTestNetwork = [
     },
     {
         testCase:
-            'eth_getTransactionReceipt - Should return correct transaction receipt - test case 1, reverted transaction',
+            'eth_getTransactionReceipt - Should return correct transaction receipt - test case 2, multiple logs',
+        hash: '0x5144c9150768535d1b4263ffe7f1756b2e2e06020ccb9cf7c5b7dc996ce92276',
+        expected: {
+            blockHash:
+                '0x0114b4a1182a9103113a4052b2d08e7785ea74901c6974f16661d352202d7bf6',
+            blockNumber: '0x114b4a1',
+            contractAddress: null,
+            cumulativeGasUsed: '0x0',
+            effectiveGasPrice: '0x0',
+            from: '0x16e3f269c3fb5dcc5844e0e5e7f8bf16270e9755',
+            gasUsed: '0x202e4',
+            logs: [
+                {
+                    address: '0xac0ca2a5148e15ef913f9f5cf8eb3cf763f5a43f',
+                    blockHash:
+                        '0x0114b4a1182a9103113a4052b2d08e7785ea74901c6974f16661d352202d7bf6',
+                    blockNumber: '0x114b4a1',
+                    data: '0x0000000000000000000000000000000000000000000000024808a928fe542eed',
+                    logIndex: '0x1',
+                    removed: false,
+                    topics: [
+                        '0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925',
+                        '0x00000000000000000000000016e3f269c3fb5dcc5844e0e5e7f8bf16270e9755',
+                        '0x0000000000000000000000009df69ad8ff89063869e04164a11579c0a8532e84'
+                    ],
+                    transactionHash:
+                        '0x5144c9150768535d1b4263ffe7f1756b2e2e06020ccb9cf7c5b7dc996ce92276',
+                    transactionIndex: '0x1'
+                },
+                {
+                    address: '0x9df69ad8ff89063869e04164a11579c0a8532e84',
+                    blockHash:
+                        '0x0114b4a1182a9103113a4052b2d08e7785ea74901c6974f16661d352202d7bf6',
+                    blockNumber: '0x114b4a1',
+                    data: '0x0000000000000000000000000000000000000000000000024808a928fe542eed',
+                    logIndex: '0x1',
+                    removed: false,
+                    topics: [
+                        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+                        '0x0000000000000000000000000000000000000000000000000000000000000000',
+                        '0x00000000000000000000000016e3f269c3fb5dcc5844e0e5e7f8bf16270e9755'
+                    ],
+                    transactionHash:
+                        '0x5144c9150768535d1b4263ffe7f1756b2e2e06020ccb9cf7c5b7dc996ce92276',
+                    transactionIndex: '0x1'
+                },
+                {
+                    address: '0x9df69ad8ff89063869e04164a11579c0a8532e84',
+                    blockHash:
+                        '0x0114b4a1182a9103113a4052b2d08e7785ea74901c6974f16661d352202d7bf6',
+                    blockNumber: '0x114b4a1',
+                    data: '0x0000000000000000000000000000000000000000000000043c47d85f5fdafe3d000000000000000000000000000000000000000000000006845081885e2f2d2a',
+                    logIndex: undefined,
+                    removed: false,
+                    topics: [
+                        '0xdec2bacdd2f05b59de34da9b523dff8be42e5e38e818c82fdb0bae774387a724',
+                        '0x00000000000000000000000016e3f269c3fb5dcc5844e0e5e7f8bf16270e9755'
+                    ],
+                    transactionHash:
+                        '0x5144c9150768535d1b4263ffe7f1756b2e2e06020ccb9cf7c5b7dc996ce92276',
+                    transactionIndex: '0x1'
+                },
+                {
+                    address: '0xac0ca2a5148e15ef913f9f5cf8eb3cf763f5a43f',
+                    blockHash:
+                        '0x0114b4a1182a9103113a4052b2d08e7785ea74901c6974f16661d352202d7bf6',
+                    blockNumber: '0x114b4a1',
+                    data: '0x0000000000000000000000000000000000000000000000024808a928fe542eed',
+                    logIndex: undefined,
+                    removed: false,
+                    topics: [
+                        '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef',
+                        '0x00000000000000000000000016e3f269c3fb5dcc5844e0e5e7f8bf16270e9755',
+                        '0x0000000000000000000000009df69ad8ff89063869e04164a11579c0a8532e84'
+                    ],
+                    transactionHash:
+                        '0x5144c9150768535d1b4263ffe7f1756b2e2e06020ccb9cf7c5b7dc996ce92276',
+                    transactionIndex: '0x1'
+                }
+            ],
+            logsBloom:
+                '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+            status: '0x1',
+            to: '0xac0ca2a5148e15ef913f9f5cf8eb3cf763f5a43f',
+            transactionHash:
+                '0x5144c9150768535d1b4263ffe7f1756b2e2e06020ccb9cf7c5b7dc996ce92276',
+            transactionIndex: '0x1',
+            type: '0x0'
+        }
+    },
+    {
+        testCase:
+            'eth_getTransactionReceipt - Should return correct transaction receipt - test case 3, reverted transaction',
         hash: '0x0000000000000000000000000b2a455fa8000000000000000000000000000000', // Simple null transaction
         expected: null
     }


### PR DESCRIPTION
Fixing the issue that using the RPC Proxy the function eth_getTransactionReceipt will only return logs of the first clause of a transaction.
The method formatTransactionReceiptToRPCStandard() was limiting the results to the first clause (outputs[0]), instead a correct receipt should return all events of a transaction.