### PR TITLE
495 thor client  option to not stop listening on interval error

### DIFF
--- a/packages/network/src/utils/poll/event.ts
+++ b/packages/network/src/utils/poll/event.ts
@@ -86,29 +86,38 @@ class EventPoll<TReturnType> extends EventEmitter {
     }
 
     /**
-     * Start listening to the event.
+     * Basic interval loop function.
+     * This function must be called into setInterval.
+     * It calls the promise and emit the event.
      */
-    startListen(): void {
-        // Start listening
-        this.emit('start', { eventPoll: this });
+    private async _intervalLoop(): Promise<void> {
+        try {
+            // Get data and emit the event
+            const data = await this.pollingFunction();
+            this.emit('data', { data, eventPoll: this });
+        } catch (error) {
+            // Set error
+            this.error = buildError(
+                'EventPoll - main interval loop function',
+                POLL_ERROR.POLL_EXECUTION_ERROR,
+                'Error during the execution of the poll',
+                {
+                    message: (error as Error).message,
+                    functionName: this.pollingFunction.name
+                }
+            );
 
-        // Execute `_intervalLoop` and then set an interval which calls `_intervalLoop` every `requestIntervalInMilliseconds`
-        void this._intervalLoop().then(() => {
-            // Create an interval
-            this.intervalId = setInterval(() => {
-                void (async () => {
-                    await this._intervalLoop();
-                })();
-            }, this.requestIntervalInMilliseconds);
-        }); // No need for .catch(), errors are handled within _intervalLoop
-    }
+            // Emit the error
+            this.emit('error', { error: this.error });
 
-    /**
-     * Stop listening to the event.
-     */
-    stopListen(): void {
-        clearInterval(this.intervalId);
-        this.emit('stop', { eventPoll: this });
+            // Stop listening?
+            if (this.isToStopOnError) {
+                this.stopListen();
+            }
+        }
+
+        // Increment the iteration
+        this.currentIteration = this.currentIteration + 1;
     }
 
     /**
@@ -145,25 +154,6 @@ class EventPoll<TReturnType> extends EventEmitter {
     /* --- Overloaded of 'on' event emitter start --- */
 
     /**
-     * Listen to the 'start' event.
-     * This happens when the poll is stopped.
-     *
-     * @param onStartCallback - The callback to be called when the event is emitted.
-     */
-    public onStart(
-        onStartCallback: (eventPoll: EventPoll<TReturnType>) => void
-    ): this {
-        this.on('start', (data) => {
-            onStartCallback(
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                data.eventPoll as EventPoll<TReturnType>
-            );
-        });
-
-        return this;
-    }
-
-    /**
      * Listen to the 'error' event.
      * This method is the redefinition of the EventEmitter.on method.
      * Because the EventEmitter.on method does not allow to specify the type of the data.
@@ -181,6 +171,25 @@ class EventPoll<TReturnType> extends EventEmitter {
             onErrorCallback(
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 error.error as Error
+            );
+        });
+
+        return this;
+    }
+
+    /**
+     * Listen to the 'start' event.
+     * This happens when the poll is stopped.
+     *
+     * @param onStartCallback - The callback to be called when the event is emitted.
+     */
+    public onStart(
+        onStartCallback: (eventPoll: EventPoll<TReturnType>) => void
+    ): this {
+        this.on('start', (data) => {
+            onStartCallback(
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+                data.eventPoll as EventPoll<TReturnType>
             );
         });
 
@@ -207,38 +216,29 @@ class EventPoll<TReturnType> extends EventEmitter {
     }
 
     /**
-     * Basic interval loop function.
-     * This function must be called into setInterval.
-     * It calls the promise and emit the event.
+     * Start listening to the event.
      */
-    private async _intervalLoop(): Promise<void> {
-        try {
-            // Get data and emit the event
-            const data = await this.pollingFunction();
-            this.emit('data', { data, eventPoll: this });
-        } catch (error) {
-            // Set error
-            this.error = buildError(
-                'EventPoll - main interval loop function',
-                POLL_ERROR.POLL_EXECUTION_ERROR,
-                'Error during the execution of the poll',
-                {
-                    message: (error as Error).message,
-                    functionName: this.pollingFunction.name
-                }
-            );
+    startListen(): void {
+        // Start listening
+        this.emit('start', { eventPoll: this });
 
-            // Emit the error
-            this.emit('error', { error: this.error });
+        // Execute `_intervalLoop` and then set an interval which calls `_intervalLoop` every `requestIntervalInMilliseconds`
+        void this._intervalLoop().then(() => {
+            // Create an interval
+            this.intervalId = setInterval(() => {
+                void (async () => {
+                    await this._intervalLoop();
+                })();
+            }, this.requestIntervalInMilliseconds);
+        }); // No need for .catch(), errors are handled within _intervalLoop
+    }
 
-            // Stop listening?
-            if (this.isToStopOnError) {
-                this.stopListen();
-            }
-        }
-
-        // Increment the iteration
-        this.currentIteration = this.currentIteration + 1;
+    /**
+     * Stop listening to the event.
+     */
+    stopListen(): void {
+        clearInterval(this.intervalId);
+        this.emit('stop', { eventPoll: this });
     }
 
     /* --- Overloaded of 'on' event emitter end --- */

--- a/packages/network/src/utils/poll/event.ts
+++ b/packages/network/src/utils/poll/event.ts
@@ -28,17 +28,17 @@ class EventPoll<TReturnType> extends EventEmitter {
     private error?: Error;
 
     /**
-     * The interval used to poll.
-     */
-    private intervalId?: NodeJS.Timeout;
-
-    /**
      * Indicates whether to stop execution on error of the
      * {@link _intervalLoop} function.
      *
      * @type {boolean}
      */
-    private readonly isToStopOnError: boolean;
+    private readonly hasToStopOnError: boolean;
+
+    /**
+     * The interval used to poll.
+     */
+    private intervalId?: NodeJS.Timeout;
 
     /**
      * The function to be called.
@@ -55,16 +55,16 @@ class EventPoll<TReturnType> extends EventEmitter {
      *
      * @param {Function} pollingFunction - The function to be executed repeatedly.
      * @param {number} requestIntervalInMilliseconds - The interval in milliseconds between each execution of the polling function.
-     * @param {boolean} [isToStopOnError=true] - Indicates whether to stop polling if an error occurs.
+     * @param {boolean} [hasToStopOnError=true] - Indicates whether to stop polling if an error occurs.
      */
     constructor(
         pollingFunction: () => Promise<TReturnType>,
         requestIntervalInMilliseconds: number,
-        isToStopOnError: boolean
+        hasToStopOnError: boolean
     ) {
         super();
         this.pollingFunction = pollingFunction;
-        this.isToStopOnError = isToStopOnError;
+        this.hasToStopOnError = hasToStopOnError;
 
         // Positive number for request interval
         assertPositiveIntegerForPollOptions(
@@ -111,7 +111,7 @@ class EventPoll<TReturnType> extends EventEmitter {
             this.emit('error', { error: this.error });
 
             // Stop listening?
-            if (this.isToStopOnError) {
+            if (this.hasToStopOnError) {
                 this.stopListen();
             }
         }
@@ -250,18 +250,18 @@ class EventPoll<TReturnType> extends EventEmitter {
  *
  * @param {Function} callBack - The callback function to be executed on each interval. It should return a Promise.
  * @param {number} requestIntervalInMilliseconds - The interval in milliseconds at which the callback function will be executed.
- * @param {boolean} [isToStopOnError=true] - Optional parameter to specify whether the poll should stop on error. Default is true.
+ * @param {boolean} [hasToStopOnError=true] - Optional parameter to specify whether the poll should stop on error. Default is true.
  * @returns {EventPoll} - The created event poll instance.
  */
 function createEventPoll<TReturnType>(
     callBack: () => Promise<TReturnType>,
     requestIntervalInMilliseconds: number,
-    isToStopOnError: boolean = true
+    hasToStopOnError: boolean = true
 ): EventPoll<TReturnType> {
     return new EventPoll<TReturnType>(
         callBack,
         requestIntervalInMilliseconds,
-        isToStopOnError
+        hasToStopOnError
     );
 }
 

--- a/packages/network/src/utils/poll/event.ts
+++ b/packages/network/src/utils/poll/event.ts
@@ -60,7 +60,7 @@ class EventPoll<TReturnType> extends EventEmitter {
     constructor(
         pollingFunction: () => Promise<TReturnType>,
         requestIntervalInMilliseconds: number,
-        isToStopOnError = true
+        isToStopOnError: boolean
     ) {
         super();
         this.pollingFunction = pollingFunction;
@@ -245,17 +245,24 @@ class EventPoll<TReturnType> extends EventEmitter {
 }
 
 /**
- * Create an event poll factory method.
+ * Creates an event poll that performs a callback function repeatedly at a specified interval.
  * This method is useful to create an event poll in a more readable way.
  *
- * @param callBack - The function to be called.
- * @param requestIntervalInMilliseconds - The interval of time (in milliseconds) between each request.
+ * @param {Function} callBack - The callback function to be executed on each interval. It should return a Promise.
+ * @param {number} requestIntervalInMilliseconds - The interval in milliseconds at which the callback function will be executed.
+ * @param {boolean} [isToStopOnError=true] - Optional parameter to specify whether the poll should stop on error. Default is true.
+ * @returns {EventPoll} - The created event poll instance.
  */
 function createEventPoll<TReturnType>(
     callBack: () => Promise<TReturnType>,
-    requestIntervalInMilliseconds: number
+    requestIntervalInMilliseconds: number,
+    isToStopOnError: boolean = true
 ): EventPoll<TReturnType> {
-    return new EventPoll<TReturnType>(callBack, requestIntervalInMilliseconds);
+    return new EventPoll<TReturnType>(
+        callBack,
+        requestIntervalInMilliseconds,
+        isToStopOnError
+    );
 }
 
 export { EventPoll, createEventPoll };

--- a/packages/network/tests/utils/poll/event/event-poll.unit.test.ts
+++ b/packages/network/tests/utils/poll/event/event-poll.unit.test.ts
@@ -115,7 +115,7 @@ describe('Events poll unit tests', () => {
         /**
          * Test the error event
          */
-        test('Test the error event', async () => {
+        test('Test the error event - polling loop stop', async () => {
             jest.useFakeTimers({
                 legacyFakeTimers: true
             });
@@ -132,6 +132,33 @@ describe('Events poll unit tests', () => {
             eventPoll.startListen();
 
             await advanceTimersByTimeAndTick(1000);
+        });
+
+        /**
+         * Test the error event without stoppoing the poll loop.
+         */
+        test('Test the error event - polling loop no-stop', async () => {
+            jest.useFakeTimers({
+                legacyFakeTimers: true
+            });
+
+            // Create event poll
+            const eventPoll = Poll.createEventPoll(
+                async () => await simpleThrowErrorFunctionIfInputIs10(10),
+                1000
+            ).onError((error) => {
+                expect(error).toBeDefined();
+                expect(error).toBeInstanceOf(PollExecutionError);
+            });
+
+            eventPoll.startListen();
+
+            await advanceTimersByTimeAndTick(1000);
+
+            expect(eventPoll.getCurrentIteration).toBe(1);
+            // Advance timers by the specified interval & tick
+            await advanceTimersByTimeAndTick(1000);
+            expect(eventPoll.getCurrentIteration).toBe(2);
         });
 
         /**


### PR DESCRIPTION
# Description

In the packages/network/src/utils/poll/event.ts the class `EventPoll` has a new private readonly `hasToStopOnError`: boolean; property to flag the _intervalLoop() if to stop in the case an error is caught.

If an error stop the poll, the code called by the onError call back can resume it calling startListen or making a new EventLoop.

Please delete options that are not relevant.

- [x] New feature:  `EventPoll` optionally stop in case of error in the event loop.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `yarn test:unit`
- [x] `yarn test:solo`

**Test Configuration**:
* Node.js Version: 22.6.2
* Yarn Version: v1.22.21

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code