### PR TITLE
feat: more account formats for proxy

### DIFF
--- a/packages/rpc-proxy/src/types.d.ts
+++ b/packages/rpc-proxy/src/types.d.ts
@@ -17,10 +17,12 @@ interface Config {
     /**
      * Accounts to use for signing transactions
      */
-    accounts: {
-        mnemonic: string;
-        count: number;
-    };
+    accounts:
+        | {
+              mnemonic: string;
+              count: number;
+          }
+        | string[];
 
     /**
      *


### PR DESCRIPTION
# Description

Same account format of hardhat:

```
"accounts": {
   "mnemonic": "...",
   "count": ...
}
```

AND

```
"accounts": [...]
```
