### PR TITLE
refactor: 666 pure and secure `packages/core/src/clause.ts`

### DIFF
--- a/packages/core/src/address/address.ts
+++ b/packages/core/src/address/address.ts
@@ -17,7 +17,7 @@ const HEX_ADDRESS_REGEX = /^0x[0-9a-f]{40}$/i;
  * - {@link secp256k1.derivePublicKey}
  *
  * @param {Uint8Array} privateKey - The private key used to compute the public key
- * from wihich the address is computed.
+ * from which the address is computed.
  * @returns {string} - The string representation of the address,
  * prefixed with `0x` according the
  * [ERC-55: Mixed-case checksum address encoding](https://eips.ethereum.org/EIPS/eip-55).

--- a/packages/core/src/clause/clause.ts
+++ b/packages/core/src/clause/clause.ts
@@ -1,9 +1,10 @@
-import { isAddress } from 'ethers';
+// import { isAddress } from 'ethers';
 import { abi, coder, type FunctionFragment } from '../abi';
 import { type TransactionClause } from '../transaction';
 import type { DeployParams } from './types';
 import { ERC721_ABI, VIP180_ABI } from '../utils';
 import { assert, buildError, DATA } from '@vechain/sdk-errors';
+import { addressUtils } from '../address';
 
 /**
  * Builds a clause for deploying a smart contract.
@@ -157,7 +158,7 @@ function transferNFT(
 
     assert(
         'transferNFT',
-        isAddress(contractAddress),
+        addressUtils.isAddress(contractAddress),
         DATA.INVALID_DATA_TYPE,
         `Invalid 'contractAddress' parameter. Expected a contract address but received ${contractAddress}.`
     );

--- a/packages/core/src/clause/clause.ts
+++ b/packages/core/src/clause/clause.ts
@@ -1,4 +1,3 @@
-// import { isAddress } from 'ethers';
 import { abi, coder, type FunctionFragment } from '../abi';
 import { type TransactionClause } from '../transaction';
 import type { DeployParams } from './types';


### PR DESCRIPTION
# Description

This tiny PR makes the code at `packages/core/src/clause/clause.ts` to depends on internal `addressUtils.isAddress` function instead of `ethers.isAddress`.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `yarn test:solo`
- [x] `yarn test:unit`

**Test Configuration**:
* Node.js Version: v21.6.2
* Yarn Version: 1.22.22

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code