### PR TITLE
fix: 897 test race condition

### DIFF
--- a/packages/network/tests/provider/rpc-mapper/methods/eth_sendTransaction/eth_sendTransaction.solo.test.ts
+++ b/packages/network/tests/provider/rpc-mapper/methods/eth_sendTransaction/eth_sendTransaction.solo.test.ts
@@ -148,12 +148,8 @@ describe('RPC Mapper - eth_sendTransaction method tests', () => {
          * Positive case 2 - Should be able to send a transaction with undefined value
          */
         test('eth_sendTransaction - Should be able to send a transaction with value undefined', async () => {
-            // THOR_SOLO_ACCOUNTS_ETH_SEND_TRANSACTION_FIXTURE.receiver.address
-            // const from = '0x7a28e7361fd10f4f058f9fefc77544349ecff5d6';
-            const from = '0xabef6032b9176c186f6bf984f548bda53349f70a';
-            // THOR_SOLO_ACCOUNTS_ETH_SEND_TRANSACTION_FIXTURE.receiver.address
-            // const to = '0xb717b660cd51109334bd10b2c168986055f58c1a';
-            const to = '0x865306084235bf804c8bba8a8d56890940ca8f0b';
+            const from = ALL_ACCOUNTS[18].address;
+            const to = ALL_ACCOUNTS[19].address;
             // Get the balance of the sender and the receiver before sending the transaction
             const balanceSenderBefore = (await provider.request({
                 method: RPC_METHODS.eth_getBalance,

--- a/packages/network/tests/provider/rpc-mapper/methods/eth_sendTransaction/eth_sendTransaction.solo.test.ts
+++ b/packages/network/tests/provider/rpc-mapper/methods/eth_sendTransaction/eth_sendTransaction.solo.test.ts
@@ -148,22 +148,20 @@ describe('RPC Mapper - eth_sendTransaction method tests', () => {
          * Positive case 2 - Should be able to send a transaction with undefined value
          */
         test('eth_sendTransaction - Should be able to send a transaction with value undefined', async () => {
+            // THOR_SOLO_ACCOUNTS_ETH_SEND_TRANSACTION_FIXTURE.receiver.address
+            // const from = '0x7a28e7361fd10f4f058f9fefc77544349ecff5d6';
+            const from = '0xabef6032b9176c186f6bf984f548bda53349f70a';
+            // THOR_SOLO_ACCOUNTS_ETH_SEND_TRANSACTION_FIXTURE.receiver.address
+            // const to = '0xb717b660cd51109334bd10b2c168986055f58c1a';
+            const to = '0x865306084235bf804c8bba8a8d56890940ca8f0b';
             // Get the balance of the sender and the receiver before sending the transaction
             const balanceSenderBefore = (await provider.request({
                 method: RPC_METHODS.eth_getBalance,
-                params: [
-                    THOR_SOLO_ACCOUNTS_ETH_SEND_TRANSACTION_FIXTURE.sender
-                        .address,
-                    'latest'
-                ]
+                params: [from, 'latest']
             })) as string;
             const balanceReceiverBefore = (await provider.request({
                 method: RPC_METHODS.eth_getBalance,
-                params: [
-                    THOR_SOLO_ACCOUNTS_ETH_SEND_TRANSACTION_FIXTURE.receiver
-                        .address,
-                    'latest'
-                ]
+                params: [to, 'latest']
             })) as string;
 
             // Send a transaction
@@ -171,10 +169,8 @@ describe('RPC Mapper - eth_sendTransaction method tests', () => {
                 method: RPC_METHODS.eth_sendTransaction,
                 params: [
                     {
-                        from: THOR_SOLO_ACCOUNTS_ETH_SEND_TRANSACTION_FIXTURE
-                            .sender.address,
-                        to: THOR_SOLO_ACCOUNTS_ETH_SEND_TRANSACTION_FIXTURE
-                            .receiver.address
+                        from,
+                        to
                     }
                 ]
             })) as string;
@@ -187,19 +183,11 @@ describe('RPC Mapper - eth_sendTransaction method tests', () => {
             // Get the balance of the sender and the receiver after sending the transaction
             const balanceSenderAfter = (await provider.request({
                 method: RPC_METHODS.eth_getBalance,
-                params: [
-                    THOR_SOLO_ACCOUNTS_ETH_SEND_TRANSACTION_FIXTURE.sender
-                        .address,
-                    'latest'
-                ]
+                params: [from, 'latest']
             })) as string;
             const balanceReceiverAfter = (await provider.request({
                 method: RPC_METHODS.eth_getBalance,
-                params: [
-                    THOR_SOLO_ACCOUNTS_ETH_SEND_TRANSACTION_FIXTURE.receiver
-                        .address,
-                    'latest'
-                ]
+                params: [to, 'latest']
             })) as string;
 
             // Compare the balances (they will remain the same)


### PR DESCRIPTION
# Description

Test **eth_sendTransaction - Should be able to send a transaction with value undefined** at `packages/network/tests/provider/rpc-mapper/methods/eth_sendTransaction/eth_sendTransaction.solo.test.ts` uses the accounts

- from = 0xabef6032b9176c186f6bf984f548bda53349f70a aka ALL_ACCOUNTS[18]
- to = 0x865306084235bf804c8bba8a8d56890940ca8f0b aka ALL_ACCOUNTS[19];

not used in any other test.

Fixes # 897

- https://github.com/vechain/vechain-sdk-js/issues/897

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `yarn test:solo`

**Test Configuration**:
* Node.js Version: v22.2.0
* Yarn Version: 1.22.22

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code