### PR TITLE
928 bug parseunits throws on numbers below 01

### DIFF
--- a/packages/core/src/utils/units/units.ts
+++ b/packages/core/src/utils/units/units.ts
@@ -268,10 +268,9 @@ function parseUnits(
         const powerOfTen = digitsOfUnit(digitsOrUnit);
         const multiplier = BigNumber(10).pow(powerOfTen);
         const result = bn.times(multiplier);
-        const f = digitsOfFractionalPart(result);
-        const i = digitsOfIntegerPart(result);
-        const text = result.toPrecision(f + i);
-        return BigInt(text);
+        const fractionDigits = digitsOfFractionalPart(result);
+        const integerDigits = digitsOfIntegerPart(result);
+        return BigInt(result.toPrecision(fractionDigits + integerDigits));
     } catch (e) {
         throw buildError(
             'unitsUtils.parseUnits',

--- a/packages/core/src/utils/units/units.ts
+++ b/packages/core/src/utils/units/units.ts
@@ -10,11 +10,6 @@ import { type WEI_UNITS } from './types';
 const BIG_NUMBER_PRECISION = 80;
 
 /**
- * Set the {@link BIG_NUMBER_PRECISION} for the fixed precision math.
- */
-BigNumber.set({ DECIMAL_PLACES: BIG_NUMBER_PRECISION });
-
-/**
  * One VET is 10^18.
  *
  * @see {formatUnits}
@@ -190,6 +185,11 @@ function formatUnits(
     value: bigint | number | string,
     decimalsOrUnit: bigint | number | WEI_UNITS = VET_DECIMAL_EXPONENT
 ): string {
+    const bnConfig = BigNumber.config();
+    BigNumber.set({
+        DECIMAL_PLACES: BIG_NUMBER_PRECISION,
+        ROUNDING_MODE: BigNumber.ROUND_HALF_UP
+    });
     try {
         const bn = bigNumberOf(value);
         const powerOfTen = digitsOfUnit(decimalsOrUnit);
@@ -208,6 +208,8 @@ function formatUnits(
             { value, digitsOrUnit: decimalsOrUnit },
             e
         );
+    } finally {
+        BigNumber.set(bnConfig);
     }
 }
 
@@ -256,13 +258,20 @@ function parseUnits(
     value: bigint | number | string,
     digitsOrUnit: bigint | number | WEI_UNITS = VET_DECIMAL_EXPONENT
 ): bigint {
+    const bnConfig = BigNumber.config();
+    BigNumber.set({
+        DECIMAL_PLACES: BIG_NUMBER_PRECISION,
+        ROUNDING_MODE: BigNumber.ROUND_HALF_UP
+    });
     try {
         const bn = bigNumberOf(value);
         const powerOfTen = digitsOfUnit(digitsOrUnit);
         const multiplier = BigNumber(10).pow(powerOfTen);
         const result = bn.times(multiplier);
-        const precisionDigits = digitsOfIntegerPart(bn) + powerOfTen;
-        return BigInt(result.toPrecision(precisionDigits));
+        const f = digitsOfFractionalPart(result);
+        const i = digitsOfIntegerPart(result);
+        const text = result.toPrecision(f + i);
+        return BigInt(text);
     } catch (e) {
         throw buildError(
             'unitsUtils.parseUnits',
@@ -271,6 +280,8 @@ function parseUnits(
             { value, decimalsOrUnit: digitsOrUnit },
             e
         );
+    } finally {
+        BigNumber.set(bnConfig);
     }
 }
 
@@ -283,7 +294,7 @@ function parseUnits(
  * This method can parse any numeric string with 18 decimals, VTHO balance too.
  *
  * @param {string} value - The value to parse as a VET amount.
- * hexadecimal supported previxed with `0x`.
+ * hexadecimal supported prefixed with `0x`.
  *
  * @returns {bigint} The parsed value as a bigint.
  *

--- a/packages/core/tests/utils/units/units.unit.test.ts
+++ b/packages/core/tests/utils/units/units.unit.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from '@jest/globals';
+import { ethers } from 'ethers';
 import { InvalidDataTypeError } from '../../../../errors';
+import { describe, expect, test } from '@jest/globals';
 import { unitsUtils, type WEI_UNITS } from '../../../src';
 
 /**
@@ -166,6 +167,20 @@ describe('unitsUtils', () => {
     });
 
     describe('parseUnits', () => {
+        test('ethers drop-in compatibility', () => {
+            const numberStrings = [
+                '0.100000000000000000',
+                '0.000000000000000001',
+                '0.099999999999999999',
+                '0.001000000000000000'
+            ];
+            numberStrings.forEach((str) => {
+                const expected = ethers.parseUnits(str, 18);
+                const actual = unitsUtils.parseUnits(str, 18);
+                expect(expected === actual).toBeTruthy();
+            });
+        });
+
         test('invalid - not a number - decimal', () => {
             const value = 'c0fee';
             expect(() => unitsUtils.parseUnits(value)).toThrowError(
@@ -295,7 +310,6 @@ describe('unitsUtils', () => {
             const expected =
                 100000000000000000000000000000000000000000000000000000000000000000000000000000000n;
             const actual = unitsUtils.parseUnits(value, decimals);
-            // const actual = BigInt(BigNumber(10).pow(80).toPrecision(81));
             expect(actual).toEqual(expected);
         });
 


### PR DESCRIPTION
# Description

The code fixes a bug in the function `unitsUtils.parseUnits` in the file packages/core/src/utils/units/units.ts leading to include non meaningful digits in BigNumber conversion to `string` to be parsed as `bigint`.

New tests are introduced to compare `ethers` behaviour with the drop-in functions provided by `unitUtils`, the latter are based on `bignumber.js` library.

The `bignumberjs` library configures its setting - specifically about the fixed digits precision and rounding methods - globally: this means if some code using this SDK needs to change `BigNumber` settings, the behaviour of `unitUtils` functions is altered in a potentially incorrect way. 

This code stores the configuration of `BigNumber`, at the beginning of the execution of the format/parse functions, set it as needed to assure 80 meaningful digits and `BigNumber.ROUND_HALF_UP` rounding methods prescribed by Ethereum specifications, restoring the configuration when the functions return.
This enhancement prevent `BigNumber` global settings collides with `unitUtils` needed setting.

Fixes # 928.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `yarn:unit`
- [x] `yarn:solo`

**Test Configuration**:
* Node.js Version: v20.14.0
* Yarn Version: 1.22.22

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code