### PR TITLE
test: tampering certificate tests added

### DIFF
--- a/packages/core/tests/certificate/certificate.unit.test.ts
+++ b/packages/core/tests/certificate/certificate.unit.test.ts
@@ -157,6 +157,81 @@ describe('certificate', () => {
             }).toThrowError(CertificateNotSignedError);
         });
 
+        test('invalid - illegal signer address', () => {
+            const signedCert = certificate.sign(cert, certPrivateKey);
+            const invalidCert = {
+                ...cert,
+                signer: '0xC1b8C0fFeE',
+                signature: signedCert.signature
+            };
+            expect(() => {
+                certificate.verify(invalidCert);
+            }).toThrowError(CertificateInvalidSignerError);
+        });
+
+        test('invalid - tampered purpose', () => {
+            const signedCert = certificate.sign(cert, certPrivateKey);
+            const invalidCert = {
+                ...cert,
+                purpose: 'tamper',
+                signature: signedCert.signature
+            };
+            expect(() => {
+                certificate.verify(invalidCert);
+            }).toThrowError(CertificateInvalidSignerError);
+        });
+
+        test('invalid - tampered payload', () => {
+            const signedCert = certificate.sign(cert, certPrivateKey);
+            const invalidCert = {
+                ...cert,
+                payload: {
+                    type: 'data',
+                    content: 'dummy'
+                },
+                signature: signedCert.signature
+            };
+            expect(() => {
+                certificate.verify(invalidCert);
+            }).toThrowError(CertificateInvalidSignerError);
+        });
+
+        test('invalid - tampered domain', () => {
+            const signedCert = certificate.sign(cert, certPrivateKey);
+            const invalidCert = {
+                ...cert,
+                domain: 'tampered',
+                signature: signedCert.signature
+            };
+            expect(() => {
+                certificate.verify(invalidCert);
+            }).toThrowError(CertificateInvalidSignerError);
+        });
+
+        test('invalid - tampered timestamp', () => {
+            const signedCert = certificate.sign(cert, certPrivateKey);
+            const invalidCert = {
+                ...cert,
+                timestamp: cert.timestamp + 1,
+                signature: signedCert.signature
+            };
+            expect(() => {
+                certificate.verify(invalidCert);
+            }).toThrowError(CertificateInvalidSignerError);
+        });
+
+        test('valid - additional property', () => {
+            const signedCert = certificate.sign(cert, certPrivateKey);
+            const ectendedCert = {
+                ...cert,
+                extendedProperty: 'extended property',
+                signature: signedCert.signature
+            };
+            expect(() => {
+                certificate.verify(ectendedCert);
+            }).not.toThrowError();
+        });
+
         test('valid - happy path', () => {
             const signedCert = certificate.sign(cert, certPrivateKey);
             expect(() => {


### PR DESCRIPTION
# Description

Despite the fact certificate signature and verification depend on the hash of the encoding of specific properties of the `Certificate` interface, and tests are already in place checking any alteration of the byte encoding of any instance of the interface, this is evident only to those knowing the internal of the certificate sign/verify process.
Additional tests are added in `packages/core/tests/certificate/certificate.unit.test.ts` challenging the `verify` method tampering one by one the sensitive properties.  

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `yarn test:solo`

**Test Configuration**:
* Node.js Version: v20.14.0
* Yarn Version: 1.22.22
* 
# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code