### PR TITLE
fix: Show Thor error message

### DIFF
--- a/packages/network/src/utils/http/http-client.ts
+++ b/packages/network/src/utils/http/http-client.ts
@@ -80,13 +80,15 @@ class HttpClient {
             clearTimeout(timeoutId);
 
             if (!response.ok) {
+                const message = await response.text();
                 throw new InvalidHTTPRequest(
                     'HttpClient.http()',
                     `Invalid URL: ${this.baseURL}${path}`,
                     {
                         method,
                         url: url.toString(),
-                        status: response.status
+                        status: response.status,
+                        message
                     }
                 );
             }

--- a/packages/network/tests/utils/http/http-client.solo.test.ts
+++ b/packages/network/tests/utils/http/http-client.solo.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from '@jest/globals';
-import { ZERO_ADDRESS, zeroAddressAccountDetails } from './fixture';
+import { InvalidHTTPRequest, stringifyData } from '@vechain/sdk-errors';
+import { fail } from 'assert';
 import { HttpClient, type HttpParams, THOR_SOLO_URL } from '../../../src';
 import { testAccount } from '../../fixture';
-import { InvalidHTTPRequest, stringifyData } from '@vechain/sdk-errors';
+import { ZERO_ADDRESS, zeroAddressAccountDetails } from './fixture';
 
 /**
  * HttpClient class tests.
@@ -30,9 +31,24 @@ describe('Test HttpClient class on Solo node', () => {
      */
     test('Should reject with an error if the HTTP request fails', async () => {
         // Assert that the HTTP request fails with an error
-        await expect(
-            soloNetwork.http('GET', '/error-test-path')
-        ).rejects.toThrowError(InvalidHTTPRequest);
+        try {
+            await soloNetwork.http('GET', '/error-test-path');
+            fail('should not get here');
+        } catch (error) {
+            expect(error).toBeInstanceOf(InvalidHTTPRequest);
+            if (error instanceof InvalidHTTPRequest) {
+                expect(error.message).toBe(
+                    `Method 'HttpClient.http()' failed.` +
+                        `\n-Reason: 'Invalid URL: http://localhost:8669/error-test-path'` +
+                        `\n-Parameters: \n\t{"method":"GET","url":"http://localhost:8669/error-test-path","message":"Request failed"}` +
+                        `\n-Internal error: ` +
+                        `\n\tMethod 'HttpClient.http()' failed.` +
+                        `\n-Reason: 'Invalid URL: http://localhost:8669/error-test-path'` +
+                        `\n-Parameters: \n\t{"method":"GET","url":"http://localhost:8669/error-test-path","status":404,"message":"404 page not found\\n"}` +
+                        `\n-Internal error: \n\tNo internal error given`
+                );
+            }
+        }
     });
 
     /**


### PR DESCRIPTION
# Description

Currently we are hiding the error message from Thor and just showing the status code. This would be an example where we just see 403:

- Actual error object `{\\\"method\\\":\\\"POST\\\",\\\"url\\\":\\\"[https://testnet.vechain.org/transactions\\\](https://testnet.vechain.org/transactions///)",\\\"status\\\":403}}}\"}}}`
- Full log:
```
-Reason: 'Method "eth_sendTransaction" failed.'
      -Parameters: 
      	{"code":-32603,"message":"Method \"eth_sendTransaction\" failed.","data":{"params":"[{\"gas\":\"0x2e271\",\"value\":\"0xde0b6b3a7640000\",\"from\":\"0x783de01f06b4f2a068a7b3bb6ff3db821a08f8c1\",\"data\":\"0x60806040526040516101e83803806101e883398101604081905261002291610053565b600080546001600160a81b0319163360ff60a01b191617600160a01b60ff939093169290920291909117905561007d565b60006020828403121561006557600080fd5b815160ff8116811461007657600080fd5b9392505050565b61015c8061008c6000396000f3fe608060405234801561001057600080fd5b50600436106100415760003560e01c8063268774ee146100465780638da5cb5b14610071578063ef5fb05b1461009c575b600080fd5b60005461005a90600160a01b900460ff1681565b60405160ff90911681526020015b60405180910390f35b600054610084906001600160a01b031681565b6040516001600160a01b039091168152602001610068565b60408051808201909152601981527f48656c6c6f20776f726c642066726f6d205665636861696e210000000000000060208201526040516100689190600060208083528351808285015260005b81811015610105578581018301518582016040015282016100e9565b506000604082860101526040601f19601f830116850101925050509291505056fea264697066735822122028b9227a42537deaf2a6662092bbef47833b3aed8bab81a1c3606ed8348f80ca64736f6c63430008140033000000000000000000000000000000000000000000000000000000000000002a\",\"to\":null}]","url":"https://testnet.vechain.org/","innerError":"{\"parent\":{\"methodName\":\"eth_sendRawTransaction()\",\"errorMessage\":\"Method \\\"eth_sendRawTransaction\\\" failed.\",\"data\":{\"code\":-32603,\"message\":\"Method \\\"eth_sendRawTransaction\\\" failed.\",\"data\":{\"params\":\"[\\\"0xf9026f278801273514fd50fa6e20f90210f9020d8080b9020860806040526040516101e83803806101e883398101604081905261002291610053565b600080546001600160a81b0319163360ff60a01b191617600160a01b60ff939093169290920291909117905561007d565b60006020828403121561006557600080fd5b815160ff8116811461007657600080fd5b9392505050565b61015c8061008c6000396000f3fe608060405234801561001057600080fd5b50600436106100415760003560e01c8063268774ee146100465780638da5cb5b14610071578063ef5fb05b1461009c575b600080fd5b60005461005a90600160a01b900460ff1681565b60405160ff90911681526020015b60405180910390f35b600054610084906001600160a01b031681565b6040516001600160a01b039091168152602001610068565b60408051808201909152601981527f48656c6c6f20776f726c642066726f6d205665636861696e210000000000000060208201526040516100689190600060208083528351808285015260005b81811015610105578581018301518582016040015282016100e9565b506000604082860101526040601f19601f830116850101925050509291505056fea264697066735822122028b9227a42537deaf2a6662092bbef47833b3aed8bab81a1c3606ed8348f80ca64736f6c63430008140033000000000000000000000000000000000000000000000000000000000000002a808302e27180867bef037e3adbc0b841cf8cf39fe0504cf5f9bbabc58b10a1b02ce15ec864cd8cda4129ea75a1ea430147215bab255ded166f110d182c0267449fbec2ad0fc126ca9b8be00de1e5279301\\\"]\",\"url\":\"[https://testnet.vechain.org\](https://testnet.vechain.org/)",\"innerError\":\"{\\\"methodName\\\":\\\"HttpClient.http()\\\",\\\"errorMessage\\\":\\\"Invalid URL: [https://testnet.vechain.org/transactions\\\](https://testnet.vechain.org/transactions///)",\\\"data\\\":{\\\"method\\\":\\\"POST\\\",\\\"url\\\":\\\"[https://testnet.vechain.org/transactions\\\](https://testnet.vechain.org/transactions///)",\\\"message\\\":\\\"Request failed\\\"},\\\"innerError\\\":{\\\"methodName\\\":\\\"HttpClient.http()\\\",\\\"errorMessage\\\":\\\"Invalid URL: [https://testnet.vechain.org/transactions\\\](https://testnet.vechain.org/transactions///)",\\\"data\\\":{\\\"method\\\":\\\"POST\\\",\\\"url\\\":\\\"[https://testnet.vechain.org/transactions\\\](https://testnet.vechain.org/transactions///)",\\\"status\\\":403}}}\"}}},\"name\":\"HardhatPluginError\",\"_stack\":\"HardhatPluginError: Error on request - eth_sendRawTransaction\\n    at HardhatVeChainProvider.buildHardhatErrorFunctionCallback (/home/runner/work/vechain-sdk-js/vechain-sdk-js/apps/sdk-hardhat-integration/node_modules/@vechain/sdk-hardhat-plugin/dist/index.js:94:26)\\n    at HardhatVeChainProvider.request (/home/runner/work/vechain-sdk-js/vechain-sdk-js/apps/sdk-hardhat-integration/node_modules/@vechain/sdk-network/dist/index.js:6797:18)\\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\\n    at async _VeChainPrivateKeySigner.sendTransaction (/home/runner/work/vechain-sdk-js/vechain-sdk-js/apps/sdk-hardhat-integration/node_modules/@vechain/sdk-network/dist/index.js:2542:12)\\n    at async ethSendTransaction (/home/runner/work/vechain-sdk-js/vechain-sdk-js/apps/sdk-hardhat-integration/node_modules/@vechain/sdk-network/dist/index.js:5424:12)\\n    at async Object.eth_sendTransaction (/home/runner/work/vechain-sdk-js/vechain-sdk-js/apps/sdk-hardhat-integration/node_modules/@vechain/sdk-network/dist/index.js:5038:14)\\n    at async HardhatVeChainProvider.request (/home/runner/work/vechain-sdk-js/vechain-sdk-js/apps/sdk-hardhat-integration/node_modules/@vechain/sdk-network/dist/index.js:6512:12)\\n    at async HardhatVeChainProvider.request (/home/runner/work/vechain-sdk-js/vechain-sdk-js/apps/sdk-hardhat-integration/node_modules/@vechain/sdk-network/dist/index.js:6773:22)\\n    at async HardhatVeChainProvider.send (/home/runner/work/vechain-sdk-js/vechain-sdk-js/apps/sdk-hardhat-integration/node_modules/@vechain/sdk-network/dist/index.js:6722:12)\\n    at async HardhatEthersSigner.sendTransaction (/home/runner/work/vechain-sdk-js/vechain-sdk-js/apps/sdk-hardhat-integration/node_modules/@nomicfoundation/hardhat-ethers/src/signers.ts:125:18)\",\"pluginName\":\"@vechain/sdk-hardhat-plugin\",\"_isHardhatPluginError\":true}"}}
```
Probably a ticket should be created to refactor how we pass parameters to `InvalidHTTPRequest` since some of the fields displayed are misleading.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

I have modified the http solo test so we can see the error message in `message`.

**Test Configuration**:
* Node.js Version: v18.12.1
* Yarn Version: 1.12.19

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code