### PR TITLE
fix(hash functions): backwards compatibility overload

### DIFF
--- a/apps/sdk-nextjs-integration/src/app/hash/page.tsx
+++ b/apps/sdk-nextjs-integration/src/app/hash/page.tsx
@@ -24,9 +24,9 @@ export default function HashPage(): JSX.Element {
     function hashContent(content: string): void {
         try {
             setHashedContent({
-                blake2b256: blake2b256(content, 'hex') as string,
-                keccak256: keccak256(content, 'hex') as string,
-                sha256: sha256(content, 'hex') as string
+                blake2b256: blake2b256(content, 'hex'),
+                keccak256: keccak256(content, 'hex'),
+                sha256: sha256(content, 'hex')
             });
         } catch (error) {
             setHashedContent({

--- a/packages/core/src/hash/Blake2b256.ts
+++ b/packages/core/src/hash/Blake2b256.ts
@@ -40,13 +40,21 @@ class Blake2b256 extends HexUInt implements Hash {
 
 // Backwards compatibility, remove in future release #1184
 
-const blake2b256 = (
-    hex: string,
+function blake2b256(
+    data: string | Uint8Array,
+    returnType: 'buffer'
+): Uint8Array;
+
+function blake2b256(data: string | Uint8Array, returnType: 'hex'): string;
+
+function blake2b256(
+    data: string | Uint8Array,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     returnType: 'buffer' | 'hex' = 'buffer'
-): string | Uint8Array =>
-    returnType === 'buffer'
-        ? Blake2b256.of(Txt.of(hex).bytes).bytes
-        : Blake2b256.of(Txt.of(hex).bytes).toString();
+): string | Uint8Array {
+    return returnType === 'buffer'
+        ? Blake2b256.of(Txt.of(data).bytes).bytes
+        : Blake2b256.of(Txt.of(data).bytes).toString();
+}
 
 export { Blake2b256, blake2b256 };

--- a/packages/core/src/hash/Keccak256.ts
+++ b/packages/core/src/hash/Keccak256.ts
@@ -38,13 +38,18 @@ class Keccak256 extends HexUInt implements Hash {
 
 // Backwards compatibility, remove in future release #1184
 
-const keccak256 = (
-    hex: string,
+function keccak256(data: string | Uint8Array, returnType: 'buffer'): Uint8Array;
+
+function keccak256(data: string | Uint8Array, returnType: 'hex'): string;
+
+function keccak256(
+    data: string | Uint8Array,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     returnType: 'buffer' | 'hex' = 'buffer'
-): string | Uint8Array =>
-    returnType === 'buffer'
-        ? Keccak256.of(Txt.of(hex).bytes).bytes
-        : Keccak256.of(Txt.of(hex).bytes).toString();
+): string | Uint8Array {
+    return returnType === 'buffer'
+        ? Keccak256.of(Txt.of(data).bytes).bytes
+        : Keccak256.of(Txt.of(data).bytes).toString();
+}
 
 export { Keccak256, keccak256 };

--- a/packages/core/src/hash/Sha256.ts
+++ b/packages/core/src/hash/Sha256.ts
@@ -36,13 +36,18 @@ class Sha256 extends HexUInt implements Hash {
 
 // Backwards compatibility, remove in future release #1184
 
-const sha256 = (
-    hex: string,
+function sha256(data: string | Uint8Array, returnType: 'buffer'): Uint8Array;
+
+function sha256(data: string | Uint8Array, returnType: 'hex'): string;
+
+function sha256(
+    data: string | Uint8Array,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     returnType: 'buffer' | 'hex' = 'buffer'
-): string | Uint8Array =>
-    returnType === 'buffer'
-        ? Sha256.of(Txt.of(hex).bytes).bytes
-        : Sha256.of(Txt.of(hex).bytes).toString();
+): string | Uint8Array {
+    return returnType === 'buffer'
+        ? Sha256.of(Txt.of(data).bytes).bytes
+        : Sha256.of(Txt.of(data).bytes).toString();
+}
 
 export { Sha256, sha256 };

--- a/packages/core/tests/hash/Blake2b256.unit.test.ts
+++ b/packages/core/tests/hash/Blake2b256.unit.test.ts
@@ -56,7 +56,7 @@ describe('Backwards compatibility tests', () => {
     });
     test('Should return the hash as buffer', () => {
         const rawString = 'Hello, World!';
-        const hash = blake2b256(rawString) as Uint8Array;
+        const hash = blake2b256(rawString, 'buffer');
         expect(bytesToHex(hash)).toBe(
             '511bc81dde11180838c562c82bb35f3223f46061ebde4a955c27b3f489cf1e03'
         );

--- a/packages/core/tests/hash/Keccak256.unit.test.ts
+++ b/packages/core/tests/hash/Keccak256.unit.test.ts
@@ -56,7 +56,7 @@ describe('Backwards compatibility tests', () => {
     });
     test('Should return the hash as buffer', () => {
         const rawString = 'Hello, World!';
-        const hash = keccak256(rawString) as Uint8Array;
+        const hash = keccak256(rawString, 'buffer');
         expect(bytesToHex(hash)).toBe(
             'acaf3289d7b601cbd114fb36c4d29c85bbfd5e133f14cb355c3fd8d99367964f'
         );

--- a/packages/core/tests/hash/Sha256.unit.test.ts
+++ b/packages/core/tests/hash/Sha256.unit.test.ts
@@ -55,7 +55,7 @@ describe('Backwards compatibility tests', () => {
     });
     test('Should return the hash as buffer', () => {
         const rawString = 'Hello, World!';
-        const hash = sha256(rawString) as Uint8Array;
+        const hash = sha256(rawString, 'buffer');
         expect(bytesToHex(hash)).toBe(
             'dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f'
         );


### PR DESCRIPTION
# Description

It adds the overload of the hash functions that was in place before the OOP approach was introduced to keep backwards compatibility.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Using the unit tests + the NextJS sample app

**Test Configuration**:
* Node.js Version: 20.12.1
* Yarn Version: 1.22.19

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code