### PR TITLE
fix: using correct types for `viem` ABI

### DIFF
--- a/packages/core/src/vcdm/abi/ABIEvent.ts
+++ b/packages/core/src/vcdm/abi/ABIEvent.ts
@@ -10,7 +10,6 @@ import {
     type Result
 } from 'ethers';
 import {
-    type AbiEvent,
     type DecodeEventLogReturnType,
     encodeEventTopics,
     type EncodeEventTopicsReturnType,
@@ -20,7 +19,7 @@ import {
 } from 'viem';
 import { Hex } from '../Hex';
 import { ABIEthersEvent } from './ABIEthersEvent';
-import { ABIItem } from './ABIItem';
+import { ABIItem, type ABIItemType } from './ABIItem';
 
 type Topics = [] | [signature: ViemHex, ...args: ViemHex[]];
 
@@ -42,7 +41,7 @@ class ABIEvent extends ABIItem {
     }): DecodeEventLogReturnType {
         try {
             return viemDecodeEventLog({
-                abi: [this.signature],
+                abi: [this.signature] as ViemABI,
                 data: event.data.toString() as ViemHex,
                 topics: event.topics.map((topic) => topic.toString()) as Topics
             });
@@ -69,7 +68,7 @@ class ABIEvent extends ABIItem {
     public encodeFilterTopics<TValue>(
         valuesToEncode: TValue[]
     ): EncodeEventTopicsReturnType {
-        const abiEvent = this.signature as unknown as AbiEvent;
+        const abiEvent = this.signature;
         if (abiEvent.inputs.length < valuesToEncode.length) {
             throw new InvalidAbiDataToEncodeOrDecode(
                 'ABIEvent.encodeEventLog',
@@ -80,7 +79,7 @@ class ABIEvent extends ABIItem {
 
         try {
             return encodeEventTopics({
-                abi: [this.signature],
+                abi: [abiEvent],
                 args: valuesToEncode
             });
         } catch (error) {
@@ -120,7 +119,7 @@ class Event<ABIType> {
                     stringAbi.replace(' list', '').replace('tuple', '')
                 );
             } else {
-                this.event = new ABIEvent(abi as ViemABI);
+                this.event = new ABIEvent(abi as ABIItemType);
             }
             this.ethersEvent = new ABIEthersEvent(abi);
             this.fragment = ethers.EventFragment.from(abi);

--- a/packages/core/src/vcdm/abi/ABIFunction.ts
+++ b/packages/core/src/vcdm/abi/ABIFunction.ts
@@ -16,11 +16,10 @@ import {
     type DecodeFunctionResultReturnType,
     encodeFunctionData,
     type EncodeFunctionDataReturnType,
-    type Abi as ViemABI,
     type Hex as ViemHex
 } from 'viem';
 import { Hex } from '../Hex';
-import { ABIItem } from './ABIItem';
+import { ABIItem, type ABIItemType } from './ABIItem';
 
 /**
  * Represents a function call in the Function ABI.
@@ -135,7 +134,7 @@ class Function<ABIType> {
                     abi.format('full').replace(' list', '').replace('tuple', '')
                 );
             } else {
-                this.function = new ABIFunction(abi as ViemABI);
+                this.function = new ABIFunction(abi as ABIItemType);
             }
             this.functionAbi = abi;
         } catch (error) {

--- a/packages/core/src/vcdm/abi/ABIItem.ts
+++ b/packages/core/src/vcdm/abi/ABIItem.ts
@@ -3,41 +3,40 @@ import {
     toFunctionHash,
     toFunctionSignature,
     type AbiEvent,
-    type AbiFunction,
-    type Abi as ViemABI
+    type AbiFunction
 } from 'viem';
 import { ABI } from './ABI';
+
+type ABIItemType = AbiFunction | AbiEvent;
 
 /**
  * Represents an ABI (Application Binary Interface) item.
  * @extends ABI
  */
 abstract class ABIItem extends ABI {
-    protected readonly signature: ViemABI;
+    protected readonly signature: ABIItemType;
     public readonly stringSignature: string;
     /**
      * ABIItem constructor from item (Event, Function...) signature.
      *
      * @param {string | ViemABI} signature - The signature of the ABI item (Function, Event...).
      **/
-    public constructor(signature: string | ViemABI) {
+    public constructor(signature: string | ABIItemType) {
         super();
         switch (typeof signature) {
             case 'string':
                 this.stringSignature = signature;
                 break;
             case 'object':
-                this.stringSignature = toFunctionSignature(
-                    signature as unknown as AbiFunction | AbiEvent
-                );
+                this.stringSignature = toFunctionSignature(signature);
                 break;
             default:
                 this.stringSignature = '';
         }
         this.signature =
-            typeof signature === 'string' && signature !== ''
+            typeof signature === 'string'
                 ? parseAbiItem([signature])
-                : (signature as ViemABI);
+                : signature;
     }
 
     /**
@@ -64,4 +63,4 @@ abstract class ABIItem extends ABI {
     }
 }
 
-export { ABIItem };
+export { ABIItem, type ABIItemType };


### PR DESCRIPTION
# Description

Since we have just `AbiFunction` and `AbiEvent`, it is more accurate to use the implementation of this PR so we avoid casts to `unknown`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Test suite of the repo

**Test Configuration**:
* Node.js Version: 20.17.0
* Yarn Version: 1.22.19

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code