### PR TITLE
1312 2 phase build for the rpc proxy dockerfile

### DIFF
--- a/packages/rpc-proxy/Dockerfile
+++ b/packages/rpc-proxy/Dockerfile
@@ -1,7 +1,7 @@
-# Use the official Node.js image as the base image
-FROM node:18-alpine
+# Stage 1: Build the app
+FROM node:20.17-alpine3.20 AS builder
 
-# Set the working directory in the container
+# Set the working directory in the builder stage
 WORKDIR /app
 
 # Copy the dependencies file to the working directory
@@ -10,8 +10,19 @@ COPY ./ /app
 # Install all the dependencies
 RUN yarn install
 
-# Build the app
+# Build the app (assumes output is in /app/dist or similar)
 RUN yarn build
 
-# Serve the app
-ENTRYPOINT ["yarn", "start"]
+# Stage 2: Serve the app using node
+FROM node:20.17.0-alpine3.20 AS runner
+
+# Set the working directory in the final stage
+WORKDIR /app
+
+# Copy only the built files and essential runtime files from the builder stage
+COPY --from=builder /app/dist /app/dist
+COPY --from=builder /app/package.json /app/
+COPY --from=builder /app/node_modules /app/node_modules
+
+# Set the default command to use node to run the app
+CMD ["node", "dist/index.js"]

--- a/packages/rpc-proxy/Dockerfile
+++ b/packages/rpc-proxy/Dockerfile
@@ -25,4 +25,4 @@ COPY --from=builder /app/package.json /app/
 COPY --from=builder /app/node_modules /app/node_modules
 
 # Set the default command to use node to run the app
-CMD ["node", "dist/index.js"]
+CMD ["node", "dist/index.js", "-c", "config.json"]


### PR DESCRIPTION
# Description

There was no build phase on the Dockerfile so I added one. The final image should only contain the files that are needed to run the application and not all of the source files and other unnecessary files.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

This is a non functional change. Ensure the dockerfile builds and runs.

**Test Configuration**:
* Node.js Version:
* Yarn Version:

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code