### PR TITLE
fix(`rpc-proxy`): Docker should not run with root

### DIFF
--- a/packages/rpc-proxy/Dockerfile
+++ b/packages/rpc-proxy/Dockerfile
@@ -19,14 +19,14 @@ FROM node:20.17.0-alpine3.20 AS runner
 # Set the working directory in the final stage
 WORKDIR /app
 
-# Create a new user to run the app so we do not use root
-RUN adduser -D rpc-proxy-user
-USER rpc-proxy-user
-
 # Copy only the built files and essential runtime files from the builder stage
 COPY --from=builder /app/dist /app/dist
 COPY --from=builder /app/package.json /app/
 COPY --from=builder /app/node_modules /app/node_modules
+
+# Create a new user to run the app so we do not use root
+RUN adduser -D rpc-proxy-user
+USER rpc-proxy-user
 
 # Set the default command to use node to run the app
 CMD ["node", "dist/index.js", "-c", "config.json"]

--- a/packages/rpc-proxy/Dockerfile
+++ b/packages/rpc-proxy/Dockerfile
@@ -19,6 +19,10 @@ FROM node:20.17.0-alpine3.20 AS runner
 # Set the working directory in the final stage
 WORKDIR /app
 
+# Create a new user to run the app so we do not use root
+RUN adduser -D rpc-proxy-user
+USER rpc-proxy-user
+
 # Copy only the built files and essential runtime files from the builder stage
 COPY --from=builder /app/dist /app/dist
 COPY --from=builder /app/package.json /app/


### PR DESCRIPTION
# Description

The pipeline is currently broken since the docker image for `rpc-proxy` [would be executed by root](https://sonarcloud.io/project/security_hotspots?id=vechain_vechain-sdk&branch=main&issueStatuses=OPEN,CONFIRMED&sinceLeakPeriod=true). This PR adds an user to solve that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

With the test suite.

**Test Configuration**:
* Node.js Version: 20.17.0
* Yarn Version: 1.22.19

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code