### PR TITLE
refactor: `ethers.Result` dependency removed from encode/decode ABI items

### DIFF
--- a/packages/core/src/vcdm/abi/ABIContract.ts
+++ b/packages/core/src/vcdm/abi/ABIContract.ts
@@ -2,7 +2,6 @@ import {
     InvalidAbiDataToEncodeOrDecode,
     InvalidAbiItem
 } from '@vechain/sdk-errors';
-import { type Result } from 'ethers';
 import {
     getAbiItem,
     parseAbi,
@@ -270,23 +269,22 @@ class ABIContract extends ABI {
     }
 
     /**
-     * DISCLAIMER: This method will be eventually deprecated in favour of viem via #1184.
      *
-     * Parses the log data and topics into an ethers format.
+     * Parses the log data and topics into an array of values.
      *
      * @param {Hex} data - The hexadecimal string of the data field in the log.
      * @param {Hex[]} topics - An array of hexadecimal strings representing the topics of the log.
-     * @deprecated
+     * @returns {unknown[]} - An array of values of the decoded log data.
      */
-    public parseEthersLog(data: Hex, topics: Hex[]): Result {
+    public parseLogAsArray(data: Hex, topics: Hex[]): unknown[] {
         const eventLogDecoded = this.parseLog(data, topics);
         if (eventLogDecoded.args === undefined) {
-            return [] as unknown as Result;
+            return [];
         } else if (eventLogDecoded.args instanceof Object) {
-            return Object.values(eventLogDecoded.args) as Result;
+            return Object.values(eventLogDecoded.args);
         }
 
-        return eventLogDecoded as unknown as Result;
+        return eventLogDecoded.args;
     }
 }
 

--- a/packages/core/src/vcdm/abi/ABIEvent.ts
+++ b/packages/core/src/vcdm/abi/ABIEvent.ts
@@ -2,7 +2,6 @@ import {
     InvalidAbiDataToEncodeOrDecode,
     InvalidAbiItem
 } from '@vechain/sdk-errors';
-import { type Result } from 'ethers';
 import {
     type AbiEvent,
     type DecodeEventLogReturnType,
@@ -107,25 +106,23 @@ class ABIEvent extends ABIItem {
     }
 
     /**
-     * DISCLAIMER: This method will be eventually deprecated in favour of viem via #1184.
-     * Decode event log data in a ethers format.
+     * Decode event log data as an array of values
      * @param {ABIEvent} event The data to decode.
-     * @returns {Result} The decoded data.
-     * @deprecated
+     * @returns {unknown[]} The decoded data as array of values.
      */
-    public decodeEthersEventLog(event: ABIEventData): Result {
+    public decodeEventLogAsArray(event: ABIEventData): unknown[] {
         try {
             const rawDecodedData = this.decodeEventLog(event);
 
-            if (rawDecodedData?.args === undefined) {
-                return [] as unknown as Result;
+            if (rawDecodedData.args === undefined) {
+                return [];
             } else if (rawDecodedData.args instanceof Object) {
-                return Object.values(rawDecodedData.args) as Result;
+                return Object.values(rawDecodedData.args);
             }
-            return rawDecodedData as unknown as Result;
+            return rawDecodedData.args as unknown[];
         } catch (error) {
             throw new InvalidAbiDataToEncodeOrDecode(
-                'ABIEvent.decodeEthersEventLog',
+                'ABIEvent.decodeEventLogAsArray',
                 'Decoding failed: Data must be a valid hex string encoding a compliant ABI type.',
                 { data: event },
                 error

--- a/packages/core/src/vcdm/abi/ABIFunction.ts
+++ b/packages/core/src/vcdm/abi/ABIFunction.ts
@@ -2,7 +2,6 @@ import {
     InvalidAbiDataToEncodeOrDecode,
     InvalidAbiItem
 } from '@vechain/sdk-errors';
-import { type Result } from 'ethers';
 import {
     type AbiFunction,
     decodeFunctionData,
@@ -128,23 +127,21 @@ class ABIFunction extends ABIItem {
     }
 
     /**
-     * DISCLAIMER: This method will be eventually deprecated in favour of viem via #1184.
-     * Decodes a function output following the ethers format.
+     * Decodes a function output returning an array of values.
      * @param {Hex} data The data to be decoded
-     * @returns {Result} The decoded data
-     * @deprecated
+     * @returns {unknown[]} The decoded data as array of values
      */
-    public decodeEthersOutput(data: Hex): Result {
+    public decodeOutputAsArray(data: Hex): unknown[] {
         const resultDecoded = this.decodeResult(data);
         if (this.functionSignature.outputs.length > 1) {
-            return this.parseObjectValues(resultDecoded as object) as Result;
+            return this.parseObjectValues(resultDecoded as object);
         } else if (
             this.functionSignature.outputs.length === 1 &&
             this.functionSignature.outputs[0].type === 'tuple'
         ) {
-            return [this.parseObjectValues(resultDecoded as object)] as Result;
+            return [this.parseObjectValues(resultDecoded as object)];
         }
-        return [resultDecoded] as Result;
+        return [resultDecoded];
     }
 }
 export { ABIFunction };

--- a/packages/core/tests/abi/abi.unit.test.ts
+++ b/packages/core/tests/abi/abi.unit.test.ts
@@ -345,7 +345,7 @@ describe('Abi - Function & Event', () => {
 
                                 // // Decode output
                                 const decoded =
-                                    myEvent.decodeEthersEventLog(encoded);
+                                    myEvent.decodeEventLogAsArray(encoded);
 
                                 // Encoded input will be equal to decoded output
                                 expect(decoded).toStrictEqual(encodingInput);

--- a/packages/network/src/thor-client/contracts/contracts-module.ts
+++ b/packages/network/src/thor-client/contracts/contracts-module.ts
@@ -17,7 +17,6 @@ import {
 import { Contract, ContractFactory } from './model';
 import type {
     ContractCallOptions,
-    ContractCallResult,
     ContractClause,
     ContractTransactionOptions
 } from './types';
@@ -81,7 +80,7 @@ class ContractsModule {
         functionAbi: ABIFunction,
         functionData: unknown[],
         contractCallOptions?: ContractCallOptions
-    ): Promise<ContractCallResult | string> {
+    ): Promise<unknown[] | string> {
         // Simulate the transaction to get the result of the contract call
         const response = await this.thor.transactions.simulateTransaction(
             [
@@ -103,9 +102,9 @@ class ContractsModule {
              */
             return decodeRevertReason(response[0].data) ?? '';
         } else {
-            // Returning ethers format (array of anonymous values). To be removed with #1184
+            // Returning an array of values.
             // The viem format is a single value/JSON object (ABIFunction#decodeResult)
-            return functionAbi.decodeEthersOutput(Hex.of(response[0].data));
+            return functionAbi.decodeOutputAsArray(Hex.of(response[0].data));
         }
     }
 
@@ -117,16 +116,16 @@ class ContractsModule {
     public async executeMultipleClausesCall(
         clauses: ContractClause[],
         options?: SimulateTransactionOptions
-    ): Promise<Array<ContractCallResult | string>> {
+    ): Promise<Array<unknown[] | string>> {
         // Simulate the transaction to get the result of the contract call
         const response = await this.thor.transactions.simulateTransaction(
             clauses.map((clause) => clause.clause),
             options
         );
-        // Returning ethers format (array of anonymous values). To be removed with #1184
+        // Returning an array of values.
         // The viem format is a single value/JSON object (ABIFunction#decodeResult)
         return response.map((res, index) =>
-            clauses[index].functionAbi.decodeEthersOutput(Hex.of(res.data))
+            clauses[index].functionAbi.decodeOutputAsArray(Hex.of(res.data))
         );
     }
 

--- a/packages/network/src/thor-client/contracts/contracts-module.ts
+++ b/packages/network/src/thor-client/contracts/contracts-module.ts
@@ -17,6 +17,7 @@ import {
 import { Contract, ContractFactory } from './model';
 import type {
     ContractCallOptions,
+    ContractCallResult,
     ContractClause,
     ContractTransactionOptions
 } from './types';
@@ -80,7 +81,7 @@ class ContractsModule {
         functionAbi: ABIFunction,
         functionData: unknown[],
         contractCallOptions?: ContractCallOptions
-    ): Promise<unknown[] | string> {
+    ): Promise<ContractCallResult | string> {
         // Simulate the transaction to get the result of the contract call
         const response = await this.thor.transactions.simulateTransaction(
             [
@@ -116,7 +117,7 @@ class ContractsModule {
     public async executeMultipleClausesCall(
         clauses: ContractClause[],
         options?: SimulateTransactionOptions
-    ): Promise<Array<unknown[] | string>> {
+    ): Promise<Array<ContractCallResult | string>> {
         // Simulate the transaction to get the result of the contract call
         const response = await this.thor.transactions.simulateTransaction(
             clauses.map((clause) => clause.clause),

--- a/packages/network/src/thor-client/contracts/types.d.ts
+++ b/packages/network/src/thor-client/contracts/types.d.ts
@@ -7,8 +7,7 @@ import type {
 import type {
     ABIFunction,
     ClauseOptions,
-    ExtendedTransactionClause,
-    vechain_sdk_core_ethers
+    ExtendedTransactionClause
 } from '@vechain/sdk-core';
 
 declare module 'abitype' {
@@ -44,7 +43,7 @@ type ContractCallOptions = SimulateTransactionOptions & ClauseOptions;
 /**
  * Represents the result of a contract call operation, encapsulating the output of the call.
  */
-type ContractCallResult = vechain_sdk_core_ethers.Result;
+type ContractCallResult = unknown[];
 
 /**
  * Represents a contract clause, which includes the clause and the corresponding function ABI.

--- a/packages/network/src/thor-client/logs/logs-module.ts
+++ b/packages/network/src/thor-client/logs/logs-module.ts
@@ -68,7 +68,7 @@ class LogsModule {
                         { type: 'event', value: log.topics[0] }
                     );
                 }
-                log.decodedData = eventAbi.decodeEthersEventLog({
+                log.decodedData = eventAbi.decodeEventLogAsArray({
                     data: Hex.of(log.data),
                     topics: log.topics.map((topic) => Hex.of(topic))
                 });
@@ -112,7 +112,7 @@ class LogsModule {
                     );
                 }
 
-                log.decodedData = eventAbi.decodeEthersEventLog({
+                log.decodedData = eventAbi.decodeEventLogAsArray({
                     data: Hex.of(log.data),
                     topics: log.topics.map((topic) => Hex.of(topic))
                 });

--- a/packages/network/src/thor-client/logs/types.d.ts
+++ b/packages/network/src/thor-client/logs/types.d.ts
@@ -1,6 +1,6 @@
 /* --- Input options start --- */
 
-import { type ABIEvent, type vechain_sdk_core_ethers } from '@vechain/sdk-core';
+import { type ABIEvent } from '@vechain/sdk-core';
 
 /**
  * Range interface for specifying a range of data.
@@ -240,7 +240,7 @@ interface EventLogs extends Event {
     /**
      * The decoded data from the event.
      */
-    decodedData?: vechain_sdk_core_ethers.Result[];
+    decodedData?: unknown[];
 }
 
 /**

--- a/packages/network/tests/thor-client/contracts/contract.erc721.solo.test.ts
+++ b/packages/network/tests/thor-client/contracts/contract.erc721.solo.test.ts
@@ -1,11 +1,6 @@
 // Global variable to hold contract address
 import { beforeAll, describe, expect, test } from '@jest/globals';
-import {
-    ABIContract,
-    ERC721_ABI,
-    Hex,
-    type vechain_sdk_core_ethers
-} from '@vechain/sdk-core';
+import { ABIContract, ERC721_ABI, Hex } from '@vechain/sdk-core';
 import {
     THOR_SOLO_URL,
     ThorClient,
@@ -131,13 +126,11 @@ describe('ThorClient - ERC721 Contracts', () => {
         }
     );
 
-    function decodeResultOutput(
-        result: TransactionReceipt
-    ): vechain_sdk_core_ethers.Result[][] {
+    function decodeResultOutput(result: TransactionReceipt): unknown[][] {
         return result?.outputs.map((output) => {
             return output.events.map((event) => {
                 // Modify when addressing #1184
-                return ABIContract.ofAbi(ERC721_ABI).parseEthersLog(
+                return ABIContract.ofAbi(ERC721_ABI).parseLogAsArray(
                     Hex.of(event.data),
                     event.topics.map((topic) => Hex.of(topic))
                 );

--- a/packages/network/tests/thor-client/contracts/contract.event.mainnet.test.ts
+++ b/packages/network/tests/thor-client/contracts/contract.event.mainnet.test.ts
@@ -47,7 +47,7 @@ describe('ThorClient - ERC20 Contracts', () => {
 
         for (const event of events) {
             if (event?.decodedData !== undefined) {
-                amount += event.decodedData[2] as unknown as bigint;
+                amount += event.decodedData[2] as bigint;
             }
         }
 


### PR DESCRIPTION
# Description

Removed `ethers.Result` dependency. Its main feature (parameter ordering) is also included by default in `viem`.

`ethers` methods converted into methods returning an array of values, so the user can decide between this or the standard `viem` output (object describing the parameters with their values).

## Type of change

- [x] Refactor of existing code.

# How Has This Been Tested?

Reusing the test suite of the SDK.

**Test Configuration**:
* Node.js Version: 20.17.0
* Yarn Version: 1.22.19

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code