### PR TITLE
refactor: 1361 gas math in bigint

### DIFF
--- a/packages/core/src/transaction/Transaction.ts
+++ b/packages/core/src/transaction/Transaction.ts
@@ -47,11 +47,11 @@ class Transaction {
      * - `NON_ZERO_GAS_DATA` - The gas cost for transmitting non-zero bytes of data.
      */
     public static readonly GAS_CONSTANTS = {
-        TX_GAS: 5000,
-        CLAUSE_GAS: 16000,
-        CLAUSE_GAS_CONTRACT_CREATION: 48000,
-        ZERO_GAS_DATA: 4,
-        NON_ZERO_GAS_DATA: 68
+        TX_GAS: 5000n,
+        CLAUSE_GAS: 16000n,
+        CLAUSE_GAS_CONTRACT_CREATION: 48000n,
+        ZERO_GAS_DATA: 4n,
+        NON_ZERO_GAS_DATA: 68n
     };
 
     /**
@@ -402,7 +402,7 @@ class Transaction {
         if (clauses.length > 0) {
             // Some clauses.
             return VTHO.of(
-                clauses.reduce((sum: number, clause: TransactionClause) => {
+                clauses.reduce((sum: bigint, clause: TransactionClause) => {
                     if (clause.to !== null) {
                         // Invalid address or no vet.domains name
                         if (
@@ -484,7 +484,7 @@ class Transaction {
         if (Transaction.isValidBody(body)) {
             if (
                 signature === undefined ||
-                Transaction._isSignatureValid(body, signature)
+                Transaction.isSignatureValid(body, signature)
             ) {
                 return new Transaction(body, signature);
             }
@@ -601,19 +601,21 @@ class Transaction {
      * Computes the amount of gas used for the given data.
      *
      * @param {string} data - The hexadecimal string data for which the gas usage is computed.
-     * @return {number} The total gas used for the provided data.
+     * @return {bigint} The total gas used for the provided data.
      * @throws {InvalidDataType} If the data is not a valid hexadecimal string.
+     *
+     * @remarks gas value is expressed in {@link Units.wei} unit.
      */
-    private static computeUsedGasFor(data: string): number {
+    private static computeUsedGasFor(data: string): bigint {
         // Invalid data
         if (data !== '' && !Hex.isValid(data))
             throw new InvalidDataType(
-                '_calculateDataUsedGas()',
+                'calculateDataUsedGas()',
                 `Invalid data type for gas calculation. Data should be a hexadecimal string.`,
                 { data }
             );
 
-        let sum = 0;
+        let sum = 0n;
         for (let i = 2; i < data.length; i += 2) {
             if (data.substring(i, i + 2) === '00') {
                 sum += Transaction.GAS_CONSTANTS.ZERO_GAS_DATA;
@@ -776,7 +778,7 @@ class Transaction {
      * @param {Uint8Array} signature - The signature to validate.
      * @return {boolean} - Returns true if the signature is valid, otherwise false.
      */
-    private static _isSignatureValid(
+    private static isSignatureValid(
         body: TransactionBody,
         signature: Uint8Array
     ): boolean {

--- a/packages/core/tests/transaction/Transaction.unit.test.ts
+++ b/packages/core/tests/transaction/Transaction.unit.test.ts
@@ -509,11 +509,9 @@ describe('Transaction class tests', () => {
                 ];
                 const actual = Transaction.intrinsicGas(clauses);
                 expect(actual.wei).toBe(
-                    BigInt(
-                        Transaction.GAS_CONSTANTS.CLAUSE_GAS_CONTRACT_CREATION +
-                            Transaction.GAS_CONSTANTS.TX_GAS +
-                            Transaction.GAS_CONSTANTS.ZERO_GAS_DATA * times
-                    )
+                    Transaction.GAS_CONSTANTS.CLAUSE_GAS_CONTRACT_CREATION +
+                        Transaction.GAS_CONSTANTS.TX_GAS +
+                        Transaction.GAS_CONSTANTS.ZERO_GAS_DATA * BigInt(times)
                 );
             });
 
@@ -528,11 +526,10 @@ describe('Transaction class tests', () => {
                 ];
                 const actual = Transaction.intrinsicGas(clauses);
                 expect(actual.wei).toBe(
-                    BigInt(
-                        Transaction.GAS_CONSTANTS.CLAUSE_GAS_CONTRACT_CREATION +
-                            Transaction.GAS_CONSTANTS.TX_GAS +
-                            Transaction.GAS_CONSTANTS.NON_ZERO_GAS_DATA * times
-                    )
+                    Transaction.GAS_CONSTANTS.CLAUSE_GAS_CONTRACT_CREATION +
+                        Transaction.GAS_CONSTANTS.TX_GAS +
+                        Transaction.GAS_CONSTANTS.NON_ZERO_GAS_DATA *
+                            BigInt(times)
                 );
             });
 
@@ -547,12 +544,12 @@ describe('Transaction class tests', () => {
                 ];
                 const actual = Transaction.intrinsicGas(clauses);
                 expect(actual.wei).toBe(
-                    BigInt(
-                        Transaction.GAS_CONSTANTS.CLAUSE_GAS_CONTRACT_CREATION +
-                            Transaction.GAS_CONSTANTS.TX_GAS +
-                            Transaction.GAS_CONSTANTS.ZERO_GAS_DATA * times +
-                            Transaction.GAS_CONSTANTS.NON_ZERO_GAS_DATA * times
-                    )
+                    Transaction.GAS_CONSTANTS.CLAUSE_GAS_CONTRACT_CREATION +
+                        Transaction.GAS_CONSTANTS.TX_GAS +
+                        Transaction.GAS_CONSTANTS.ZERO_GAS_DATA *
+                            BigInt(times) +
+                        Transaction.GAS_CONSTANTS.NON_ZERO_GAS_DATA *
+                            BigInt(times)
                 );
             });
         });
@@ -593,10 +590,8 @@ describe('Transaction class tests', () => {
                 }) as TransactionClause[];
                 const actual = Transaction.intrinsicGas(clauses);
                 expect(actual.wei).toBe(
-                    BigInt(
-                        Transaction.GAS_CONSTANTS.CLAUSE_GAS * times +
-                            Transaction.GAS_CONSTANTS.TX_GAS
-                    )
+                    Transaction.GAS_CONSTANTS.CLAUSE_GAS * BigInt(times) +
+                        Transaction.GAS_CONSTANTS.TX_GAS
                 );
             });
         });


### PR DESCRIPTION
# Description

The class `packages/core/src/transaction/Transaction.ts` uses `bigint` type instead of `number` to compute gas.  The use of `bigint` avoids approximation due to the chain of sums of products of big numbers since gas values are at least 18 decimal digits long.

## Type of change

Internal enhancement only.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `yarn test:unit`
- [x] `yarn test:solo`

**Test Configuration**:
* Node.js Version: v22.8.0
* Yarn Version: 1.22.22

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code