### PR TITLE
feat: eth_getTransactionCount can return 0x0 const if configured

### DIFF
--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -51,6 +51,13 @@ extendEnvironment((hre) => {
         networkConfig.enableDelegation !== undefined &&
         networkConfig.enableDelegation;
 
+    // 1.5 - Get the custom RPC Configuration
+    const rpcConfiguration = networkConfig.rpcConfiguration;
+    const ethGetTransactionCountMustReturn0 =
+        rpcConfiguration?.ethGetTransactionCountMustReturn0 !== undefined
+            ? rpcConfiguration?.ethGetTransactionCountMustReturn0
+            : false;
+
     // 2 - Check if network is vechain
 
     if (!networkName.includes('vechain')) {
@@ -73,6 +80,7 @@ extendEnvironment((hre) => {
 
     // 3 - Extend environment with the 'HardhatVeChainProvider'
 
+    console.log('networkConfig', networkConfig.rpcConfiguration);
     // 3.1 - Create the provider
     const hardhatVeChainProvider = new HardhatVeChainProvider(
         createWalletFromHardhatNetworkConfig(networkConfig),
@@ -84,7 +92,10 @@ extendEnvironment((hre) => {
                 parent
             ),
         debug,
-        enableDelegation
+        enableDelegation,
+        {
+            ethGetTransactionCountMustReturn0
+        }
     );
 
     // 3.2 - Extend environment

--- a/packages/hardhat-plugin/src/type-extensions.ts
+++ b/packages/hardhat-plugin/src/type-extensions.ts
@@ -59,5 +59,12 @@ declare module 'hardhat/types/config' {
          * Enable or not the fee's delegation of the transaction.
          */
         enableDelegation?: boolean;
+
+        /**
+         * RPC Configuration
+         */
+        rpcConfiguration?: {
+            ethGetTransactionCountMustReturn0: boolean;
+        };
     }
 }

--- a/packages/hardhat-plugin/tests/eth_getTransactionCount-default-value-project.unit.test.ts
+++ b/packages/hardhat-plugin/tests/eth_getTransactionCount-default-value-project.unit.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+
+import { resetHardhatContext } from 'hardhat/plugins-testing';
+import {
+    type HardhatRuntimeEnvironment,
+    type HttpNetworkConfig
+} from 'hardhat/types';
+import { setHardhatContext } from './test-utils';
+
+/**
+ * Simple hardhat project eth_getTransactionCount-default-value-project network configuration defined
+ *
+ * @group unit/eth_getTransactionCount-default-value-project
+ */
+describe('Using eth_getTransactionCount with default value as 0x0', () => {
+    /**
+     * Init hardhat runtime environment
+     */
+    let hre: HardhatRuntimeEnvironment;
+
+    beforeEach(async function () {
+        // Set hardhat context
+        setHardhatContext('eth_getTransactionCount-default-value-project');
+
+        // Load hardhat environment
+        hre = await import('hardhat');
+    });
+
+    afterEach(function () {
+        resetHardhatContext();
+    });
+
+    /**
+     * Test suite for eth_getTransactionCount with default 0x0 value
+     */
+    describe('Custom network configuration hardhat', () => {
+        /**
+         * Positive test cases for createWalletFromHardhatNetworkConfig function
+         */
+        test('Should be able to get a default value of 0x0 from a project', async () => {
+            // Network configuration should be defined
+            expect(hre.config.networks.vechain_testnet).toBeDefined();
+
+            // Initialize network configuration AND check ethGetTransactionCountDefaultValue parameter
+            const networkConfig = hre.config.networks
+                .vechain_testnet as HttpNetworkConfig;
+            expect(
+                networkConfig.rpcConfiguration
+                    ?.ethGetTransactionCountMustReturn0
+            ).toBe(true);
+
+            // Get the provider
+            expect(hre.VeChainProvider).toBeDefined();
+            const provider = hre.VeChainProvider;
+
+            // Expect 0 as the default value
+            const request = await provider?.request({
+                method: 'eth_getTransactionCount',
+                params: ['0x0b41c56e19c5151122568873a039fEa090937Fe2', 'latest']
+            });
+            expect(request).toBe('0x0');
+        });
+    });
+});

--- a/packages/hardhat-plugin/tests/eth_getTransactionCount-no-value-project.unit.test.ts
+++ b/packages/hardhat-plugin/tests/eth_getTransactionCount-no-value-project.unit.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+
+import { resetHardhatContext } from 'hardhat/plugins-testing';
+import {
+    type HardhatRuntimeEnvironment,
+    type HttpNetworkConfig
+} from 'hardhat/types';
+import { setHardhatContext } from './test-utils';
+
+/**
+ * Simple hardhat project eth_getTransactionCount-no-value-project network configuration defined
+ *
+ * @group unit/eth_getTransactionCount-no-value-project
+ */
+describe('Using eth_getTransactionCount with no options specified. So it will return a random number', () => {
+    /**
+     * Init hardhat runtime environment
+     */
+    let hre: HardhatRuntimeEnvironment;
+
+    beforeEach(async function () {
+        // Set hardhat context
+        setHardhatContext('eth_getTransactionCount-no-value-project');
+
+        // Load hardhat environment
+        hre = await import('hardhat');
+    });
+
+    afterEach(function () {
+        resetHardhatContext();
+    });
+
+    /**
+     * Test suite for eth_getTransactionCount with random value when no options are specified
+     */
+    describe('Custom network configuration hardhat', () => {
+        /**
+         * Should be able to get a random value from a project when no options are specified
+         */
+        test('Should be able to get a random value from a project when no options are specified', async () => {
+            // Network configuration should be defined
+            expect(hre.config.networks.vechain_testnet).toBeDefined();
+
+            // Initialize network configuration AND check ethGetTransactionCountDefaultValue parameter
+            const networkConfig = hre.config.networks
+                .vechain_testnet as HttpNetworkConfig;
+            expect(
+                networkConfig.rpcConfiguration
+                    ?.ethGetTransactionCountMustReturn0
+            ).toBe(undefined);
+
+            // Get the provider
+            expect(hre.VeChainProvider).toBeDefined();
+            const provider = hre.VeChainProvider;
+
+            // Expect 0 as the default value
+            const request = await provider?.request({
+                method: 'eth_getTransactionCount',
+                params: ['0x0b41c56e19c5151122568873a039fEa090937Fe2', 'latest']
+            });
+            expect(request).not.toBe('0x0');
+        });
+    });
+});

--- a/packages/hardhat-plugin/tests/eth_getTransactionCount-random-value-project.unit.test.ts
+++ b/packages/hardhat-plugin/tests/eth_getTransactionCount-random-value-project.unit.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+
+import { resetHardhatContext } from 'hardhat/plugins-testing';
+import {
+    type HardhatRuntimeEnvironment,
+    type HttpNetworkConfig
+} from 'hardhat/types';
+import { setHardhatContext } from './test-utils';
+
+/**
+ * Simple hardhat project eth_getTransactionCount-random-value-project network configuration defined
+ *
+ * @group unit/eth_getTransactionCount-random-value-project
+ */
+describe('Using eth_getTransactionCount with random value (not the default 0x0 value)', () => {
+    /**
+     * Init hardhat runtime environment
+     */
+    let hre: HardhatRuntimeEnvironment;
+
+    beforeEach(async function () {
+        // Set hardhat context
+        setHardhatContext('eth_getTransactionCount-random-value-project');
+
+        // Load hardhat environment
+        hre = await import('hardhat');
+    });
+
+    afterEach(function () {
+        resetHardhatContext();
+    });
+
+    /**
+     * Test suite for eth_getTransactionCount with random value
+     */
+    describe('Custom network configuration hardhat', () => {
+        /**
+         * Should be able to get random value from eth_getTransactionCount
+         */
+        test('Should be able to get random value from eth_getTransactionCount', async () => {
+            // Network configuration should be defined
+            expect(hre.config.networks.vechain_testnet).toBeDefined();
+
+            // Initialize network configuration AND check ethGetTransactionCountDefaultValue parameter
+            const networkConfig = hre.config.networks
+                .vechain_testnet as HttpNetworkConfig;
+            expect(
+                networkConfig.rpcConfiguration
+                    ?.ethGetTransactionCountMustReturn0
+            ).toBe(false);
+
+            // Get the provider
+            expect(hre.VeChainProvider).toBeDefined();
+            const provider = hre.VeChainProvider;
+
+            // Expect 0 as the default value
+            const request = await provider?.request({
+                method: 'eth_getTransactionCount',
+                params: ['0x0b41c56e19c5151122568873a039fEa090937Fe2', 'latest']
+            });
+            expect(request).not.toBe('0x0');
+        });
+    });
+});

--- a/packages/hardhat-plugin/tests/hardhat-mock-projects/eth_getTransactionCount-default-value-project/hardhat.config.ts
+++ b/packages/hardhat-plugin/tests/hardhat-mock-projects/eth_getTransactionCount-default-value-project/hardhat.config.ts
@@ -1,0 +1,64 @@
+/**
+ * Simple hardhat configuration for testing with a VeChain network defined
+ */
+
+// We load the plugin here.
+import { type HardhatUserConfig, type HttpNetworkConfig } from 'hardhat/types';
+
+import '../../../src/index';
+import { HDKey } from '@vechain/sdk-core';
+
+/**
+ * Simple configuration for testing
+ */
+const vechainTestNetwork: HttpNetworkConfig = {
+    // Default network parameters
+    url: 'https://testnet.vechain.org',
+    timeout: 20000,
+    httpHeaders: {},
+    gas: 'auto',
+    gasPrice: 'auto',
+    gasMultiplier: 1,
+    accounts: {
+        mnemonic:
+            'vivid any call mammal mosquito budget midnight expose spirit approve reject system',
+        path: HDKey.VET_DERIVATION_PATH,
+        count: 3,
+        initialIndex: 0,
+        passphrase: 'VeChainThor'
+    },
+
+    // Custom parameters
+    delegator: {
+        delegatorPrivateKey:
+            'ea5383ac1f9e625220039a4afac6a7f868bf1ad4f48ce3a1dd78bd214ee4ace5'
+    },
+    debug: true,
+    enableDelegation: true,
+
+    // Custom RPC
+    rpcConfiguration: {
+        ethGetTransactionCountMustReturn0: true
+    }
+};
+
+/**
+ * Hardhat configuration
+ */
+const config: HardhatUserConfig = {
+    solidity: '0.8.17',
+    networks: {
+        vechain_testnet: vechainTestNetwork
+    },
+
+    /**
+     * @note: here we set vechain_testnet as the default network to simulate a command like this:
+     *
+     * ```sh
+     * npx hardhat --network vechain_testnet <command>
+     * ```
+     */
+    defaultNetwork: 'vechain_testnet'
+};
+
+export default config;

--- a/packages/hardhat-plugin/tests/hardhat-mock-projects/eth_getTransactionCount-no-value-project/hardhat.config.ts
+++ b/packages/hardhat-plugin/tests/hardhat-mock-projects/eth_getTransactionCount-no-value-project/hardhat.config.ts
@@ -1,0 +1,62 @@
+/**
+ * Simple hardhat configuration for testing with a VeChain network defined
+ */
+
+// We load the plugin here.
+import { type HardhatUserConfig, type HttpNetworkConfig } from 'hardhat/types';
+
+import '../../../src/index';
+import { HDKey } from '@vechain/sdk-core';
+
+/**
+ * Simple configuration for testing
+ */
+const vechainTestNetwork: HttpNetworkConfig = {
+    // Default network parameters
+    url: 'https://testnet.vechain.org',
+    timeout: 20000,
+    httpHeaders: {},
+    gas: 'auto',
+    gasPrice: 'auto',
+    gasMultiplier: 1,
+    accounts: {
+        mnemonic:
+            'vivid any call mammal mosquito budget midnight expose spirit approve reject system',
+        path: HDKey.VET_DERIVATION_PATH,
+        count: 3,
+        initialIndex: 0,
+        passphrase: 'VeChainThor'
+    },
+
+    // Custom parameters
+    delegator: {
+        delegatorPrivateKey:
+            'ea5383ac1f9e625220039a4afac6a7f868bf1ad4f48ce3a1dd78bd214ee4ace5'
+    },
+    debug: true,
+    enableDelegation: true
+
+    // Custom RPC
+    // ... NOT GIVEN ...
+};
+
+/**
+ * Hardhat configuration
+ */
+const config: HardhatUserConfig = {
+    solidity: '0.8.17',
+    networks: {
+        vechain_testnet: vechainTestNetwork
+    },
+
+    /**
+     * @note: here we set vechain_testnet as the default network to simulate a command like this:
+     *
+     * ```sh
+     * npx hardhat --network vechain_testnet <command>
+     * ```
+     */
+    defaultNetwork: 'vechain_testnet'
+};
+
+export default config;

--- a/packages/hardhat-plugin/tests/hardhat-mock-projects/eth_getTransactionCount-random-value-project/hardhat.config.ts
+++ b/packages/hardhat-plugin/tests/hardhat-mock-projects/eth_getTransactionCount-random-value-project/hardhat.config.ts
@@ -1,0 +1,64 @@
+/**
+ * Simple hardhat configuration for testing with a VeChain network defined
+ */
+
+// We load the plugin here.
+import { type HardhatUserConfig, type HttpNetworkConfig } from 'hardhat/types';
+
+import '../../../src/index';
+import { HDKey } from '@vechain/sdk-core';
+
+/**
+ * Simple configuration for testing
+ */
+const vechainTestNetwork: HttpNetworkConfig = {
+    // Default network parameters
+    url: 'https://testnet.vechain.org',
+    timeout: 20000,
+    httpHeaders: {},
+    gas: 'auto',
+    gasPrice: 'auto',
+    gasMultiplier: 1,
+    accounts: {
+        mnemonic:
+            'vivid any call mammal mosquito budget midnight expose spirit approve reject system',
+        path: HDKey.VET_DERIVATION_PATH,
+        count: 3,
+        initialIndex: 0,
+        passphrase: 'VeChainThor'
+    },
+
+    // Custom parameters
+    delegator: {
+        delegatorPrivateKey:
+            'ea5383ac1f9e625220039a4afac6a7f868bf1ad4f48ce3a1dd78bd214ee4ace5'
+    },
+    debug: true,
+    enableDelegation: true,
+
+    // Custom RPC
+    rpcConfiguration: {
+        ethGetTransactionCountMustReturn0: false
+    }
+};
+
+/**
+ * Hardhat configuration
+ */
+const config: HardhatUserConfig = {
+    solidity: '0.8.17',
+    networks: {
+        vechain_testnet: vechainTestNetwork
+    },
+
+    /**
+     * @note: here we set vechain_testnet as the default network to simulate a command like this:
+     *
+     * ```sh
+     * npx hardhat --network vechain_testnet <command>
+     * ```
+     */
+    defaultNetwork: 'vechain_testnet'
+};
+
+export default config;

--- a/packages/network/tests/provider/providers/hardhat/hardhat-provider.testnet.test.ts
+++ b/packages/network/tests/provider/providers/hardhat/hardhat-provider.testnet.test.ts
@@ -113,4 +113,61 @@ describe('Hardhat provider tests - testnet', () => {
                 })
         ).rejects.toThrowError();
     });
+
+    /**
+     * Custom RPC configuration tests
+     */
+    describe('Custom RPC configuration tests', () => {
+        /**
+         * Should return 0 when calling eth_getTransactionCount with rpcConfiguration.ethGetTransactionCountDefaultValue set to true
+         */
+        test('Should return 0 when calling eth_getTransactionCount with rpcConfiguration.ethGetTransactionCountMustReturn0 set to true', async () => {
+            // Set the custom RPC configuration
+            const providerWithCustomRPCConfiguration =
+                new HardhatVeChainProvider(
+                    new ProviderInternalBaseWallet([]),
+                    TESTNET_URL,
+                    (message: string, parent?: Error) =>
+                        new Error(message, parent),
+                    false,
+                    false,
+                    { ethGetTransactionCountMustReturn0: true }
+                );
+
+            // Call RPC function
+            const rpcCall = await providerWithCustomRPCConfiguration.request({
+                method: 'eth_getTransactionCount',
+                params: ['0x7567d83b7b8d80addcb281a71d54fc7b3364ffed', 'latest']
+            });
+
+            // Compare the result with the expected value
+            expect(rpcCall).toBe('0x0');
+        });
+
+        /**
+         * Should NOT return 0 when calling eth_getTransactionCount with rpcConfiguration.ethGetTransactionCountDefaultValue set to false
+         */
+        test('Should NOT return 0 when calling eth_getTransactionCount with rpcConfiguration.ethGetTransactionCountMustReturn0 set to false', async () => {
+            // Set the custom RPC configuration
+            const providerWithCustomRPCConfiguration =
+                new HardhatVeChainProvider(
+                    new ProviderInternalBaseWallet([]),
+                    TESTNET_URL,
+                    (message: string, parent?: Error) =>
+                        new Error(message, parent),
+                    false,
+                    false,
+                    { ethGetTransactionCountMustReturn0: false }
+                );
+
+            // Call RPC function
+            const rpcCall = await providerWithCustomRPCConfiguration.request({
+                method: 'eth_getTransactionCount',
+                params: ['0x7567d83b7b8d80addcb281a71d54fc7b3364ffed', 'latest']
+            });
+
+            // Compare the result with the expected value
+            expect(rpcCall).not.toBe('0x0');
+        });
+    });
 });


### PR DESCRIPTION
# Description

Add the capability to choose wether we can return 0x0 or a random number for eth_getTransactionCount RPC endpoint