### PR TITLE
refactor: using nested error codes for `JSONRPCProviderError` classes

### DIFF
--- a/packages/errors/src/available-errors/provider/provider.ts
+++ b/packages/errors/src/available-errors/provider/provider.ts
@@ -1,5 +1,5 @@
 import { VechainSDKError } from '../sdk-error';
-import { type ObjectErrorData } from '../types';
+import type { JSONRpcErrorCode, ObjectErrorData } from '../types';
 
 /**
  * Provider generic error.
@@ -9,31 +9,19 @@ import { type ObjectErrorData } from '../types';
  *
  * @see{https://www.jsonrpc.org/specification#error_object}
  */
-class JSONRPCProviderError<
-    TJSONRpcErrorCode extends
-        | -32700
-        | -32600
-        | -32601
-        | -32602
-        | -32603
-        | -32000
-> extends VechainSDKError<{
-    code: TJSONRpcErrorCode;
+class JSONRPCProviderError extends VechainSDKError<{
+    code: JSONRpcErrorCode;
     message: string;
     data: ObjectErrorData;
 }> {
     constructor(
         readonly methodName: string,
+        code: JSONRpcErrorCode,
         message: string,
         data: ObjectErrorData,
         readonly innerError?: unknown
     ) {
-        super(
-            methodName,
-            message,
-            { code: undefined as unknown as TJSONRpcErrorCode, message, data },
-            innerError
-        );
+        super(methodName, message, { code, message, data }, innerError);
     }
 }
 
@@ -43,7 +31,16 @@ class JSONRPCProviderError<
  * WHEN TO USE:
  * * Invalid JSON was received by the server. An error occurred on the server while parsing the JSON text.
  */
-class JSONRPCParseError extends JSONRPCProviderError<-32700> {}
+class JSONRPCParseError extends JSONRPCProviderError {
+    constructor(
+        readonly methodName: string,
+        message: string,
+        data: ObjectErrorData,
+        readonly innerError?: unknown
+    ) {
+        super(methodName, -32700, message, data, innerError);
+    }
+}
 
 /**
  * Invalid request.
@@ -51,7 +48,16 @@ class JSONRPCParseError extends JSONRPCProviderError<-32700> {}
  * WHEN TO USE:
  * * The JSON sent is not a valid Request object.
  */
-class JSONRPCInvalidRequest extends JSONRPCProviderError<-32600> {}
+class JSONRPCInvalidRequest extends JSONRPCProviderError {
+    constructor(
+        readonly methodName: string,
+        message: string,
+        data: ObjectErrorData,
+        readonly innerError?: unknown
+    ) {
+        super(methodName, -32600, message, data, innerError);
+    }
+}
 
 /**
  * Method not found.
@@ -59,7 +65,16 @@ class JSONRPCInvalidRequest extends JSONRPCProviderError<-32600> {}
  * WHEN TO USE:
  * * The method does not exist / is not available.
  */
-class JSONRPCMethodNotFound extends JSONRPCProviderError<-32601> {}
+class JSONRPCMethodNotFound extends JSONRPCProviderError {
+    constructor(
+        readonly methodName: string,
+        message: string,
+        data: ObjectErrorData,
+        readonly innerError?: unknown
+    ) {
+        super(methodName, -32601, message, data, innerError);
+    }
+}
 
 /**
  * Invalid params.
@@ -67,7 +82,16 @@ class JSONRPCMethodNotFound extends JSONRPCProviderError<-32601> {}
  * WHEN TO USE:
  * * Invalid method parameter(s).
  */
-class JSONRPCInvalidParams extends JSONRPCProviderError<-32602> {}
+class JSONRPCInvalidParams extends JSONRPCProviderError {
+    constructor(
+        readonly methodName: string,
+        message: string,
+        data: ObjectErrorData,
+        readonly innerError?: unknown
+    ) {
+        super(methodName, -32602, message, data, innerError);
+    }
+}
 
 /**
  * Internal JSON-RPC error.
@@ -75,7 +99,16 @@ class JSONRPCInvalidParams extends JSONRPCProviderError<-32602> {}
  * WHEN TO USE:
  * * Internal JSON-RPC error.
  */
-class JSONRPCInternalError extends JSONRPCProviderError<-32603> {}
+class JSONRPCInternalError extends JSONRPCProviderError {
+    constructor(
+        readonly methodName: string,
+        message: string,
+        data: ObjectErrorData,
+        readonly innerError?: unknown
+    ) {
+        super(methodName, -32603, message, data, innerError);
+    }
+}
 
 /**
  * Server error.
@@ -83,7 +116,16 @@ class JSONRPCInternalError extends JSONRPCProviderError<-32603> {}
  * WHEN TO USE:
  * * Reserved for implementation-defined server-errors.
  */
-class JSONRPCServerError extends JSONRPCProviderError<-32000> {}
+class JSONRPCServerError extends JSONRPCProviderError {
+    constructor(
+        readonly methodName: string,
+        message: string,
+        data: ObjectErrorData,
+        readonly innerError?: unknown
+    ) {
+        super(methodName, -32000, message, data, innerError);
+    }
+}
 
 export {
     JSONRPCInternalError,

--- a/packages/errors/src/available-errors/provider/provider.ts
+++ b/packages/errors/src/available-errors/provider/provider.ts
@@ -24,12 +24,16 @@ class JSONRPCProviderError<
 }> {
     constructor(
         readonly methodName: string,
-        code: TJSONRpcErrorCode,
         message: string,
         data: ObjectErrorData,
         readonly innerError?: unknown
     ) {
-        super(methodName, message, { code, message, data }, innerError);
+        super(
+            methodName,
+            message,
+            { code: undefined as unknown as TJSONRpcErrorCode, message, data },
+            innerError
+        );
     }
 }
 
@@ -82,11 +86,11 @@ class JSONRPCInternalError extends JSONRPCProviderError<-32603> {}
 class JSONRPCServerError extends JSONRPCProviderError<-32000> {}
 
 export {
-    JSONRPCProviderError,
-    JSONRPCParseError,
+    JSONRPCInternalError,
+    JSONRPCInvalidParams,
     JSONRPCInvalidRequest,
     JSONRPCMethodNotFound,
-    JSONRPCInvalidParams,
-    JSONRPCInternalError,
+    JSONRPCParseError,
+    JSONRPCProviderError,
     JSONRPCServerError
 };

--- a/packages/errors/src/available-errors/types.d.ts
+++ b/packages/errors/src/available-errors/types.d.ts
@@ -2,5 +2,6 @@
  * Default Object error data type. it accepts any object.
  */
 type ObjectErrorData = Record<string, unknown>;
+type JSONRpcErrorCode = -32700 | -32600 | -32601 | -32602 | -32603 | -32000;
 
-export type { ObjectErrorData };
+export type { ObjectErrorData, JSONRpcErrorCode };

--- a/packages/errors/tests/available-errors/provider.unit.test.ts
+++ b/packages/errors/tests/available-errors/provider.unit.test.ts
@@ -23,7 +23,6 @@ describe('Error package Available errors test - Provider', () => {
             expect(() => {
                 throw new JSONRPCParseError(
                     'method',
-                    -32700,
                     'message',
                     { data: 'data' },
                     innerError
@@ -41,7 +40,6 @@ describe('Error package Available errors test - Provider', () => {
             expect(() => {
                 throw new JSONRPCInvalidRequest(
                     'method',
-                    -32600,
                     'message',
                     { data: 'data' },
                     innerError
@@ -59,7 +57,6 @@ describe('Error package Available errors test - Provider', () => {
             expect(() => {
                 throw new JSONRPCMethodNotFound(
                     'method',
-                    -32601,
                     'message',
                     { data: 'data' },
                     innerError
@@ -77,7 +74,6 @@ describe('Error package Available errors test - Provider', () => {
             expect(() => {
                 throw new JSONRPCInvalidParams(
                     'method',
-                    -32602,
                     'message',
                     { data: 'data' },
                     innerError
@@ -95,7 +91,6 @@ describe('Error package Available errors test - Provider', () => {
             expect(() => {
                 throw new JSONRPCInternalError(
                     'method',
-                    -32603,
                     'message',
                     { data: 'data' },
                     innerError
@@ -113,7 +108,6 @@ describe('Error package Available errors test - Provider', () => {
             expect(() => {
                 throw new JSONRPCServerError(
                     'method',
-                    -32000,
                     'message',
                     { data: 'data' },
                     innerError

--- a/packages/hardhat-plugin/src/helpers/provider-helper.ts
+++ b/packages/hardhat-plugin/src/helpers/provider-helper.ts
@@ -37,7 +37,6 @@ const createWalletFromHardhatNetworkConfig = (
         if (accountFromConfig === 'remote')
             throw new JSONRPCInternalError(
                 'createWalletFromHardhatNetworkConfig()',
-                -32603,
                 'Remote accounts are not supported in hardhat network configuration.',
                 { accountFromConfig, networkConfig }
             );

--- a/packages/logging/tests/error-logger.unit.test.ts
+++ b/packages/logging/tests/error-logger.unit.test.ts
@@ -15,14 +15,9 @@ describe('Error logger tests', () => {
         const logSpy = jest.spyOn(VeChainSDKLogger('error'), 'log');
 
         VeChainSDKLogger('error').log(
-            new JSONRPCInternalError(
-                'test-method',
-                -32603,
-                `Error on request`,
-                {
-                    some: 'data'
-                }
-            )
+            new JSONRPCInternalError('test-method', `Error on request`, {
+                some: 'data'
+            })
         );
 
         expect(logSpy).toHaveBeenCalled();

--- a/packages/network/src/provider/providers/hardhat-provider/hardhat-provider.ts
+++ b/packages/network/src/provider/providers/hardhat-provider/hardhat-provider.ts
@@ -176,7 +176,6 @@ class HardhatVeChainProvider extends VeChainProvider {
                 VeChainSDKLogger('error').log(
                     new JSONRPCInternalError(
                         args.method,
-                        -32603,
                         `Error on request - ${args.method}`,
                         {
                             args

--- a/packages/network/src/provider/providers/vechain-provider/vechain-provider.ts
+++ b/packages/network/src/provider/providers/vechain-provider/vechain-provider.ts
@@ -63,7 +63,6 @@ class VeChainProvider extends EventEmitter implements EIP1193ProviderMessage {
         if (enableDelegation && wallet?.delegator === undefined) {
             throw new JSONRPCInvalidParams(
                 'VechainProvider constructor',
-                -32602,
                 'Delegation is enabled but the delegator is not defined. Ensure that the delegator is defined and connected to the network.',
                 { wallet }
             );
@@ -99,7 +98,6 @@ class VeChainProvider extends EventEmitter implements EIP1193ProviderMessage {
         ) {
             throw new JSONRPCMethodNotFound(
                 'VeChainProvider.request()',
-                -32601,
                 'Method not found. Invalid RPC method given as input.',
                 { method: args.method }
             );

--- a/packages/network/src/provider/utils/rpc-mapper/methods/debug_traceBlockByHash/debug_traceBlockByHash.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/debug_traceBlockByHash/debug_traceBlockByHash.ts
@@ -46,7 +46,6 @@ const debugTraceBlockByHash = async (
     )
         throw new JSONRPCInvalidParams(
             'debug_traceBlockByHash',
-            -32602,
             `Invalid input params for "debug_traceBlockByHash" method. See https://www.quicknode.com/docs/ethereum/debug_traceBlockByHash for details.`,
             { params }
         );
@@ -86,7 +85,6 @@ const debugTraceBlockByHash = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'debug_traceBlockByHash()',
-            -32603,
             'Method "debug_traceBlockByHash" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/debug_traceBlockByNumber/debug_traceBlockByNumber.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/debug_traceBlockByNumber/debug_traceBlockByNumber.ts
@@ -44,7 +44,6 @@ const debugTraceBlockByNumber = async (
     )
         throw new JSONRPCInvalidParams(
             'debug_traceBlockByNumber',
-            -32602,
             `Invalid input params for "debug_traceBlockByNumber" method. See https://www.quicknode.com/docs/ethereum/debug_traceBlockByNumber for details.`,
             { params }
         );
@@ -87,7 +86,6 @@ const debugTraceBlockByNumber = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'debug_traceBlockByNumber()',
-            -32603,
             'Method "debug_traceBlockByNumber" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/debug_traceCall/debug_traceCall.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/debug_traceCall/debug_traceCall.ts
@@ -47,7 +47,6 @@ const debugTraceCall = async (
     )
         throw new JSONRPCInvalidParams(
             'debug_traceCall',
-            -32602,
             `Invalid input params for "debug_traceCall" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -84,7 +83,6 @@ const debugTraceCall = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'debug_traceCall()',
-            -32603,
             'Method "debug_traceCall" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/debug_traceTransaction/debug_traceTransaction.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/debug_traceTransaction/debug_traceTransaction.ts
@@ -45,7 +45,6 @@ const debugTraceTransaction = async (
     )
         throw new JSONRPCInvalidParams(
             'debug_traceTransaction',
-            -32602,
             `Invalid input params for "debug_traceTransaction" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -87,7 +86,6 @@ const debugTraceTransaction = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'debug_traceTransaction()',
-            -32603,
             'Method "debug_traceTransaction" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_blockNumber/eth_blockNumber.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_blockNumber/eth_blockNumber.ts
@@ -21,7 +21,6 @@ const ethBlockNumber = async (thorClient: ThorClient): Promise<string> => {
     } catch (e) {
         throw new JSONRPCInternalError(
             'eth_blockNumber()',
-            -32603,
             'Method "eth_blockNumber" failed.',
             {
                 url: thorClient.httpClient.baseURL,

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_call/eth_call.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_call/eth_call.ts
@@ -34,7 +34,6 @@ const ethCall = async (
     )
         throw new JSONRPCInvalidParams(
             'eth_call',
-            -32602,
             `Invalid input params for "eth_call" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -70,7 +69,6 @@ const ethCall = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'eth_call()',
-            -32603,
             'Method "eth_call" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_chainId/eth_chainId.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_chainId/eth_chainId.ts
@@ -24,7 +24,6 @@ const ethChainId = async (thorClient: ThorClient): Promise<string> => {
         if (genesisBlock?.id === null || genesisBlock?.id === undefined) {
             throw new JSONRPCInvalidParams(
                 'eth_chainId()',
-                -32602,
                 'The genesis block id is null or undefined. Unable to get the chain id.',
                 {
                     url: thorClient.httpClient.baseURL
@@ -41,7 +40,6 @@ const ethChainId = async (thorClient: ThorClient): Promise<string> => {
     } catch (e) {
         throw new JSONRPCInternalError(
             'eth_chainId()',
-            -32603,
             'Method "eth_chainId" failed.',
             {
                 url: thorClient.httpClient.baseURL,

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_estimateGas/eth_estimateGas.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_estimateGas/eth_estimateGas.ts
@@ -34,7 +34,6 @@ const ethEstimateGas = async (
     if (![1, 2].includes(params.length) || typeof params[0] !== 'object')
         throw new JSONRPCInvalidParams(
             'eth_estimateGas',
-            -32602,
             `Invalid input params for "eth_estimateGas" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -70,7 +69,6 @@ const ethEstimateGas = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'eth_estimateGas()',
-            -32603,
             'Method "eth_estimateGas" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getBalance/eth_getBalance.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getBalance/eth_getBalance.ts
@@ -34,7 +34,6 @@ const ethGetBalance = async (
     )
         throw new JSONRPCInvalidParams(
             'eth_getBalance',
-            -32602,
             `Invalid input params for "eth_getBalance" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -51,7 +50,6 @@ const ethGetBalance = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'eth_getBalance()',
-            -32603,
             'Method "eth_getBalance" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getBlockByHash/eth_getBlockByHash.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getBlockByHash/eth_getBlockByHash.ts
@@ -34,7 +34,6 @@ const ethGetBlockByHash = async (
     )
         throw new JSONRPCInvalidParams(
             'eth_getBlockByHash',
-            -32602,
             `Invalid input params for "eth_getBlockByHash" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -45,7 +44,6 @@ const ethGetBlockByHash = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'eth_getBlockByHash()',
-            -32603,
             'Method "eth_getBlockByHash" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getBlockByNumber/eth_getBlockByNumber.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getBlockByNumber/eth_getBlockByNumber.ts
@@ -37,7 +37,6 @@ const ethGetBlockByNumber = async (
     )
         throw new JSONRPCInvalidParams(
             'eth_getBlockByNumber',
-            -32602,
             `Invalid input params for "eth_getBlockByNumber" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -66,7 +65,6 @@ const ethGetBlockByNumber = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'eth_getBlockByNumber()',
-            -32603,
             'Method "eth_getBlockByNumber" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getBlockReceipts/eth_getBlockReceipts.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getBlockReceipts/eth_getBlockReceipts.ts
@@ -31,7 +31,6 @@ const ethGetBlockReceipts = async (
     if (params.length !== 1 || typeof params[0] !== 'string')
         throw new JSONRPCInvalidParams(
             'eth_getBlockReceipts',
-            -32602,
             `Invalid input params for "eth_getBlockReceipts" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -69,7 +68,6 @@ const ethGetBlockReceipts = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'eth_getBlockReceipts()',
-            -32603,
             'Method "eth_getBlockReceipts" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getBlockTransactionCountByHash/eth_getBlockTransactionCountByHash.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getBlockTransactionCountByHash/eth_getBlockTransactionCountByHash.ts
@@ -27,7 +27,6 @@ const ethGetBlockTransactionCountByHash = async (
     )
         throw new JSONRPCInvalidParams(
             'eth_getBlockTransactionCountByHash',
-            -32602,
             `Invalid input params for "eth_getBlockTransactionCountByHash" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getBlockTransactionCountByNumber/eth_getBlockTransactionCountByNumber.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getBlockTransactionCountByNumber/eth_getBlockTransactionCountByNumber.ts
@@ -22,7 +22,6 @@ const ethGetBlockTransactionCountByNumber = async (
     if (params.length !== 1 || typeof params[0] !== 'string')
         throw new JSONRPCInvalidParams(
             'eth_getBlockTransactionCountByNumber',
-            -32602,
             `Invalid input params for "eth_getBlockTransactionCountByNumber" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getCode/eth_getCode.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getCode/eth_getCode.ts
@@ -34,7 +34,6 @@ const ethGetCode = async (
     )
         throw new JSONRPCInvalidParams(
             'eth_getCode',
-            -32602,
             `Invalid input params for "eth_getCode" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -49,7 +48,6 @@ const ethGetCode = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'eth_getCode()',
-            -32603,
             'Method "eth_getCode" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getLogs/eth_getLogs.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getLogs/eth_getLogs.ts
@@ -34,7 +34,6 @@ const ethGetLogs = async (
     if (params.length !== 1 || typeof params[0] !== 'object')
         throw new JSONRPCInvalidParams(
             'eth_getLogs',
-            -32602,
             `Invalid input params for "eth_getLogs" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -93,7 +92,6 @@ const ethGetLogs = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'eth_getLogs()',
-            -32603,
             'Method "eth_getLogs" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getStorageAt/eth_getStorageAt.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getStorageAt/eth_getStorageAt.ts
@@ -37,7 +37,6 @@ const ethGetStorageAt = async (
     )
         throw new JSONRPCInvalidParams(
             'eth_getStorageAt',
-            -32602,
             `Invalid input params for "eth_getStorageAt" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -60,7 +59,6 @@ const ethGetStorageAt = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'eth_getStorageAt()',
-            -32603,
             'Method "eth_getStorageAt" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getTransactionByBlockHashAndIndex/eth_getTransactionByBlockHashAndIndex.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getTransactionByBlockHashAndIndex/eth_getTransactionByBlockHashAndIndex.ts
@@ -32,7 +32,6 @@ const ethGetTransactionByBlockHashAndIndex = async (
     )
         throw new JSONRPCInvalidParams(
             'eth_getTransactionByBlockHashAndIndex',
-            -32602,
             `Invalid input params for "eth_getTransactionByBlockHashAndIndex" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -59,7 +58,6 @@ const ethGetTransactionByBlockHashAndIndex = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'eth_getTransactionByBlockHashAndIndex()',
-            -32603,
             'Method "eth_getTransactionByBlockHashAndIndex" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getTransactionByBlockNumberAndIndex/eth_getTransactionByBlockNumberAndIndex.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getTransactionByBlockNumberAndIndex/eth_getTransactionByBlockNumberAndIndex.ts
@@ -32,7 +32,6 @@ const ethGetTransactionByBlockNumberAndIndex = async (
     )
         throw new JSONRPCInvalidParams(
             'eth_getTransactionByBlockNumberAndIndex',
-            -32602,
             `Invalid input params for "eth_getTransactionByBlockNumberAndIndex" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -59,7 +58,6 @@ const ethGetTransactionByBlockNumberAndIndex = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'eth_getTransactionByBlockNumberAndIndex()',
-            -32603,
             'Method "eth_getTransactionByBlockNumberAndIndex" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getTransactionByHash/eth_getTransactionByHash.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getTransactionByHash/eth_getTransactionByHash.ts
@@ -29,7 +29,6 @@ const ethGetTransactionByHash = async (
     if (params.length !== 1 || typeof params[0] !== 'string')
         throw new JSONRPCInvalidParams(
             'eth_getTransactionByHash',
-            -32602,
             `Invalid input params for "eth_getTransactionByHash" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -60,7 +59,6 @@ const ethGetTransactionByHash = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'eth_getTransactionByHash()',
-            -32603,
             'Method "eth_getTransactionByHash" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getTransactionCount/eth_getTransactionCount.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getTransactionCount/eth_getTransactionCount.ts
@@ -24,7 +24,6 @@ const ethGetTransactionCount = async (params: unknown[]): Promise<string> => {
     )
         throw new JSONRPCInvalidParams(
             'eth_getTransactionCount',
-            -32602,
             `Invalid input params for "eth_getTransactionCount" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -33,7 +32,6 @@ const ethGetTransactionCount = async (params: unknown[]): Promise<string> => {
     if (!Address.isValid(params[0])) {
         throw new JSONRPCInvalidParams(
             'eth_getTransactionCount',
-            -32602,
             'Invalid address, expected a 20 bytes address string.',
             { params }
         );

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getTransactionReceipt/eth_getTransactionReceipt.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getTransactionReceipt/eth_getTransactionReceipt.ts
@@ -35,7 +35,6 @@ const ethGetTransactionReceipt = async (
     if (params.length !== 1 || typeof params[0] !== 'string')
         throw new JSONRPCInvalidParams(
             'eth_getTransactionReceipt',
-            -32602,
             `Invalid input params for "eth_getTransactionReceipt" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -44,7 +43,6 @@ const ethGetTransactionReceipt = async (
     if (!ThorId.isValid(params[0])) {
         throw new JSONRPCInvalidParams(
             'eth_getTransactionReceipt',
-            -32602,
             'Invalid transaction ID given as input. Input must be an hex string of length 64.',
             { params }
         );
@@ -89,7 +87,6 @@ const ethGetTransactionReceipt = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'eth_getTransactionReceipt()',
-            -32603,
             'Method "eth_getTransactionReceipt" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getUncleByBlockHashAndIndex/eth_getUncleByBlockHashAndIndex.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getUncleByBlockHashAndIndex/eth_getUncleByBlockHashAndIndex.ts
@@ -29,7 +29,6 @@ const ethGetUncleByBlockHashAndIndex = async (
     )
         throw new JSONRPCInvalidParams(
             'eth_getUncleByBlockHashAndIndex',
-            -32602,
             'Invalid input params for "eth_getUncleByBlockHashAndIndex" method. See https://docs.infura.io/api/networks/ethereum/json-rpc-methods/eth_getunclebyblockhashandindex for details.',
             { params }
         );

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getUncleByBlockNumberAndIndex/eth_getUncleByBlockNumberAndIndex.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getUncleByBlockNumberAndIndex/eth_getUncleByBlockNumberAndIndex.ts
@@ -28,7 +28,6 @@ const ethGetUncleByBlockNumberAndIndex = async (
     )
         throw new JSONRPCInvalidParams(
             'eth_getUncleByBlockNumberAndIndex',
-            -32602,
             'Invalid input params for "eth_getUncleByBlockNumberAndIndex" method. See https://docs.infura.io/api/networks/ethereum/json-rpc-methods/eth_getunclebyblocknumberandindex for details.',
             { params }
         );

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getUncleCountByBlockHash/eth_getUncleCountByBlockHash.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getUncleCountByBlockHash/eth_getUncleCountByBlockHash.ts
@@ -19,7 +19,6 @@ const ethGetUncleCountByBlockHash = async (
     )
         throw new JSONRPCInvalidParams(
             'eth_getUncleCountByBlockHash',
-            -32602,
             `Invalid input params for "eth_getUncleCountByBlockHash" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getUncleCountByBlockNumber/eth_getUncleCountByBlockNumber.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getUncleCountByBlockNumber/eth_getUncleCountByBlockNumber.ts
@@ -14,7 +14,6 @@ const ethGetUncleCountByBlockNumber = async (
     if (params.length !== 1 || typeof params[0] !== 'string')
         throw new JSONRPCInvalidParams(
             'eth_getUncleCountByBlockNumber',
-            -32602,
             `Invalid input params for "eth_getUncleCountByBlockNumber" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_requestAccounts/eth_requestAccounts.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_requestAccounts/eth_requestAccounts.ts
@@ -20,7 +20,6 @@ const ethRequestAccounts = async (
     if (accounts.length === 0)
         throw new JSONRPCInvalidParams(
             'eth_requestAccounts()',
-            -32602,
             'Method "eth_requestAccounts" failed.',
             {
                 provider: stringifyData(provider)

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_sendRawTransaction/eth_sendRawTransaction.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_sendRawTransaction/eth_sendRawTransaction.ts
@@ -25,7 +25,6 @@ const ethSendRawTransaction = async (
     if (params.length !== 1 || typeof params[0] !== 'string')
         throw new JSONRPCInvalidParams(
             'eth_sendRawTransaction()',
-            -32602,
             `Invalid input params for "eth_sendRawTransaction" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -34,7 +33,6 @@ const ethSendRawTransaction = async (
     if (!Hex.isValid0x(params[0])) {
         throw new JSONRPCInvalidParams(
             'eth_sendRawTransaction()',
-            -32602,
             'Invalid transaction encoded data given as input. Input must be a hex string.',
             { params }
         );
@@ -52,7 +50,6 @@ const ethSendRawTransaction = async (
     } catch (error) {
         throw new JSONRPCInternalError(
             'eth_sendRawTransaction()',
-            -32603,
             'Method "eth_sendRawTransaction" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_sendTransaction/eth_sendTransaction.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_sendTransaction/eth_sendTransaction.ts
@@ -44,7 +44,6 @@ const ethSendTransaction = async (
     if (params.length !== 1 || typeof params[0] !== 'object')
         throw new JSONRPCInvalidParams(
             'eth_sendTransaction',
-            -32602,
             `Invalid input params for "eth_sendTransaction" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -53,7 +52,6 @@ const ethSendTransaction = async (
     if (provider?.wallet === undefined) {
         throw new JSONRPCInvalidParams(
             'eth_sendTransaction',
-            -32602,
             'Provider must be defined with a wallet. Ensure that the provider is defined and connected to the network.',
             { provider }
         );
@@ -63,7 +61,6 @@ const ethSendTransaction = async (
     if ((params[0] as TransactionObjectInput).from === undefined) {
         throw new JSONRPCInvalidParams(
             'eth_sendTransaction',
-            -32602,
             'From field is required in the transaction object.',
             { provider }
         );
@@ -83,7 +80,6 @@ const ethSendTransaction = async (
     } catch (error) {
         throw new JSONRPCInternalError(
             'eth_sendTransaction()',
-            -32603,
             'Method "eth_sendTransaction" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_signTransaction/eth_signTransaction.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_signTransaction/eth_signTransaction.ts
@@ -36,7 +36,6 @@ const ethSignTransaction = async (
     if (params.length !== 1 || typeof params[0] !== 'object')
         throw new JSONRPCInvalidParams(
             'eth_signTransaction',
-            -32602,
             `Invalid input params for "eth_signTransaction" method. See ${RPC_DOCUMENTATION_URL} for details.`,
             { params }
         );
@@ -45,7 +44,6 @@ const ethSignTransaction = async (
     if (provider?.wallet === undefined) {
         throw new JSONRPCInvalidParams(
             'eth_signTransaction',
-            -32602,
             'Provider must be defined with a wallet. Ensure that the provider is defined and connected to the network.',
             { provider }
         );
@@ -55,7 +53,6 @@ const ethSignTransaction = async (
     if ((params[0] as TransactionObjectInput).from === undefined) {
         throw new JSONRPCInvalidParams(
             'eth_signTransaction',
-            -32602,
             'From field is required in the transaction object.',
             { provider }
         );
@@ -75,7 +72,6 @@ const ethSignTransaction = async (
     } catch (error) {
         throw new JSONRPCInternalError(
             'eth_signTransaction()',
-            -32603,
             'Method "eth_signTransaction" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_signTypedData_v4/eth_signTypedData_v4.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_signTypedData_v4/eth_signTypedData_v4.ts
@@ -38,7 +38,6 @@ const ethSignTypedDataV4 = async (
     )
         throw new JSONRPCInvalidParams(
             'eth_signTypedDataV4',
-            -32602,
             `Invalid input params for "eth_signTypedDataV4" method. See https://docs.metamask.io/wallet/reference/eth_signtypeddata_v4/ for details.`,
             { params }
         );
@@ -50,7 +49,6 @@ const ethSignTypedDataV4 = async (
     ) {
         throw new JSONRPCInvalidParams(
             'eth_signTypedDataV4',
-            -32602,
             `Provider must be defined with a wallet. Ensure that the provider is defined, connected to the network and has the wallet with the address ${params[0]} into it.`,
             { provider }
         );
@@ -80,7 +78,6 @@ const ethSignTypedDataV4 = async (
     } catch (error) {
         throw new JSONRPCInternalError(
             'eth_signTypedDataV4',
-            -32603,
             'Method "eth_signTypedDataV4" failed.',
             {
                 params: stringifyData(params),

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_subscribe/eth_subscribe.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_subscribe/eth_subscribe.ts
@@ -60,7 +60,6 @@ const ethSubscribe = async (
     if (provider === undefined) {
         throw new JSONRPCInternalError(
             'eth_subscribe()',
-            -32603,
             'Method "eth_subscribe" failed. Provider is not defined.',
             {
                 url: thorClient.httpClient.baseURL,
@@ -74,7 +73,6 @@ const ethSubscribe = async (
     ) {
         throw new JSONRPCInvalidParams(
             'eth_subscribe()',
-            -32602,
             'Method "eth_subscribe" failed. Invalid subscription type param.',
             {
                 url: thorClient.httpClient.baseURL,
@@ -92,7 +90,6 @@ const ethSubscribe = async (
         } else
             throw new JSONRPCServerError(
                 'eth_subscribe()',
-                -32000,
                 'Method "eth_subscribe" failed. Best block not available.',
                 {
                     url: thorClient.httpClient.baseURL,

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_syncing/eth_syncing.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_syncing/eth_syncing.ts
@@ -75,7 +75,6 @@ const ethSyncing = async (
     } catch (e) {
         throw new JSONRPCInternalError(
             'eth_syncing()',
-            -32603,
             'Method "eth_syncing" failed.',
             {
                 url: thorClient.httpClient.baseURL,

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_unsubscribe/eth_unsubscribe.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_unsubscribe/eth_unsubscribe.ts
@@ -30,7 +30,6 @@ const ethUnsubscribe = async (
     if (provider === undefined) {
         throw new JSONRPCInternalError(
             'eth_unsubscribe()',
-            -32603,
             'Method "eth_unsubscribe" failed. Provider is not defined.',
             {
                 params: stringifyData(params)

--- a/packages/network/src/provider/utils/rpc-mapper/methods/evm_mine/evm_mine.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/evm_mine/evm_mine.ts
@@ -31,7 +31,6 @@ const evmMine = async (thorClient: ThorClient): Promise<BlocksRPC | null> => {
     } catch (e) {
         throw new JSONRPCInternalError(
             'evm_mine()',
-            -32603,
             'Method "evm_mine" failed.',
             {
                 url: thorClient.httpClient.baseURL,

--- a/packages/network/src/provider/utils/rpc-mapper/methods/net_listening/net_listening.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/net_listening/net_listening.ts
@@ -14,7 +14,6 @@ const netListening = async (thorClient: ThorClient): Promise<boolean> => {
     } catch (e) {
         throw new JSONRPCInternalError(
             'net_listening()',
-            -32603,
             'Method "net_listening" failed.',
             {
                 url: thorClient.httpClient.baseURL,

--- a/packages/network/src/provider/utils/rpc-mapper/methods/net_peerCount/net_peerCount.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/net_peerCount/net_peerCount.ts
@@ -15,7 +15,6 @@ const netPeerCount = async (thorClient: ThorClient): Promise<number> => {
     } catch (e) {
         throw new JSONRPCInternalError(
             'net_peerCount()',
-            -32603,
             'Method "net_peerCount" failed.',
             {
                 url: thorClient.httpClient.baseURL,

--- a/packages/network/src/provider/utils/rpc-mapper/methods/txpool_contentFrom/txpool_contentFrom.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/txpool_contentFrom/txpool_contentFrom.ts
@@ -22,7 +22,6 @@ const txPoolContentFrom = async (params: unknown[]): Promise<object> => {
     )
         throw new JSONRPCInvalidParams(
             'txpool_contentFrom()',
-            -32602,
             `Invalid input params for "txpool_contentFrom" method. See https://www.quicknode.com/docs/ethereum/txpool_contentFrom for details.`,
             { params }
         );

--- a/packages/network/src/provider/utils/rpc-mapper/methods/web3_sha3/web3_sha3.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/web3_sha3/web3_sha3.ts
@@ -18,7 +18,6 @@ const web3Sha3 = async (params: unknown[]): Promise<string> => {
     )
         throw new JSONRPCInvalidParams(
             'web3_sha3',
-            -32602,
             `Invalid input params for "web3_sha3" method. See 'https://docs.alchemy.com/reference/web3-sha3' for details.`,
             { params }
         );

--- a/packages/network/src/signer/signers/vechain-abstract-signer/vechain-abstract-signer.ts
+++ b/packages/network/src/signer/signers/vechain-abstract-signer/vechain-abstract-signer.ts
@@ -140,7 +140,6 @@ abstract class VeChainAbstractSigner implements VeChainSigner {
         if ((this.provider as AvailableVeChainProviders) === null) {
             throw new JSONRPCInvalidParams(
                 'VechainAbstractSigner.populateTransaction()',
-                -32602,
                 'Thor client not found into the signer. Please attach a Provider with a thor client to your signer instance.',
                 { provider: this.provider }
             );
@@ -196,7 +195,6 @@ abstract class VeChainAbstractSigner implements VeChainSigner {
         if ((this.provider as AvailableVeChainProviders) === null) {
             throw new JSONRPCInvalidParams(
                 'VechainAbstractSigner.estimateGas()',
-                -32602,
                 'Thor client not found into the signer. Please attach a Provider with a thor client to your signer instance.',
                 { provider: this.provider }
             );
@@ -243,7 +241,6 @@ abstract class VeChainAbstractSigner implements VeChainSigner {
         if ((this.provider as AvailableVeChainProviders) === null) {
             throw new JSONRPCInvalidParams(
                 'VechainAbstractSigner.call()',
-                -32602,
                 'Thor client not found into the signer. Please attach a Provider with a thor client to your signer instance.',
                 { provider: this.provider }
             );

--- a/packages/network/src/signer/signers/vechain-private-key-signer/vechain-private-key-signer.ts
+++ b/packages/network/src/signer/signers/vechain-private-key-signer/vechain-private-key-signer.ts
@@ -97,7 +97,6 @@ class VeChainPrivateKeySigner extends VeChainAbstractSigner {
         if (this.provider === null) {
             throw new JSONRPCInvalidParams(
                 'VeChainPrivateKeySigner.signTransaction()',
-                -32602,
                 'Thor provider is not found into the signer. Please attach a Provider to your signer instance.',
                 { transactionToSign }
             );
@@ -129,7 +128,6 @@ class VeChainPrivateKeySigner extends VeChainAbstractSigner {
         if (this.provider === null) {
             throw new JSONRPCInvalidParams(
                 'VeChainPrivateKeySigner.sendTransaction()',
-                -32602,
                 'Thor provider is not found into the signer. Please attach a Provider to your signer instance.',
                 { transactionToSend }
             );

--- a/packages/network/tests/provider/providers/vechain/vechain-provider.solo.test.ts
+++ b/packages/network/tests/provider/providers/vechain/vechain-provider.solo.test.ts
@@ -15,6 +15,7 @@ import {
     deployERC721Contract,
     waitForMessage
 } from '../helpers';
+import { fail } from 'assert';
 
 /**
  *VeChain provider tests - Solo Network
@@ -352,13 +353,22 @@ describe('VeChain provider tests - solo', () => {
         expect(provider).toBeDefined();
 
         // Call RPC function
-        await expect(
-            async () =>
-                await provider.request({
-                    method: 'INVALID_METHOD',
-                    params: [-1]
-                })
-        ).rejects.toThrowError(JSONRPCMethodNotFound);
+        try {
+            await provider.request({
+                method: 'INVALID_METHOD',
+                params: [-1]
+            });
+            fail('Should throw an error');
+        } catch (error) {
+            expect(error).toBeInstanceOf(JSONRPCMethodNotFound);
+            if (error instanceof JSONRPCMethodNotFound) {
+                expect(error.message).toBe(
+                    `Method 'VeChainProvider.request()' failed.` +
+                        `\n-Reason: 'Method not found. Invalid RPC method given as input.'` +
+                        `\n-Parameters: \n\t{\n  "code": -32601,\n  "message": "Method not found. Invalid RPC method given as input.",\n  "data": {\n    "method": "INVALID_METHOD"\n  }\n}`
+                );
+            }
+        }
     });
 
     describe('resolveName(vnsName)', () => {

--- a/packages/rpc-proxy/src/index.ts
+++ b/packages/rpc-proxy/src/index.ts
@@ -137,11 +137,11 @@ function startProxy(): void {
                             messages: [`response: ${stringifyData(result)}`]
                         });
                     }
-                } catch (e) {
+                } catch (error) {
                     // Push the error to the responses array
                     responses.push({
                         jsonrpc: '2.0',
-                        error: e,
+                        error,
                         id: requestBody.id
                     });
 
@@ -149,10 +149,9 @@ function startProxy(): void {
                     VeChainSDKLogger('error').log(
                         new JSONRPCInternalError(
                             requestBody.method,
-                            -32603,
                             `Error on request - ${requestBody.method}`,
                             { requestBody },
-                            e
+                            error
                         )
                     );
                 }


### PR DESCRIPTION
# Description

Before this PR as part of the instance of a subclass of a `JSONRPCProviderError` we had to pass the code when it was already included as part of the class definition as a generic. This PR removes that need and allows you to declare the code in a single place.

## Type of change

- [x] Refactor of existing code

# How Has This Been Tested?

Using the SDK test suite + one test modified to show the actual code of the error

**Test Configuration**:
* Node.js Version: 20.17.0
* Yarn Version: 1.22.19

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code