### PR TITLE
refactor: returning connected peers after dealing with null

### DIFF
--- a/docs/templates/thor-client.md
+++ b/docs/templates/thor-client.md
@@ -84,7 +84,7 @@ The Thor-client allows developers to interact with nodes on the VeChainThor netw
 
 In this example, the code initializes a Thor client for the VeChainThor testnet network and utilizes the `getNodes` method to retrieve information about connected peers.
 
- - `getNodes(): Promise<ConnectedPeer | null>`
+ - `getNodes(): Promise<ConnectedPeer[]>`
 
 The `getNodes` method simplifies the process of obtaining details about connected peers of a node in the VeChainThor network. The method returns information about the connected peers, allowing developers to monitor and analyze the network's node connectivity.
 

--- a/docs/thor-client.md
+++ b/docs/thor-client.md
@@ -197,7 +197,7 @@ const peerNodes = await thorClient.nodes.getNodes();
 
 In this example, the code initializes a Thor client for the VeChainThor testnet network and utilizes the `getNodes` method to retrieve information about connected peers.
 
- - `getNodes(): Promise<ConnectedPeer | null>`
+ - `getNodes(): Promise<ConnectedPeer[]>`
 
 The `getNodes` method simplifies the process of obtaining details about connected peers of a node in the VeChainThor network. The method returns information about the connected peers, allowing developers to monitor and analyze the network's node connectivity.
 

--- a/packages/network/src/provider/utils/rpc-mapper/methods/net_peerCount/net_peerCount.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/net_peerCount/net_peerCount.ts
@@ -11,7 +11,7 @@ import { JSONRPCInternalError, stringifyData } from '@vechain/sdk-errors';
 const netPeerCount = async (thorClient: ThorClient): Promise<number> => {
     try {
         const peers = await thorClient.nodes.getNodes();
-        return peers !== null ? peers.length : 0;
+        return peers.length;
     } catch (e) {
         throw new JSONRPCInternalError(
             'net_peerCount()',

--- a/packages/network/src/thor-client/nodes/nodes-module.ts
+++ b/packages/network/src/thor-client/nodes/nodes-module.ts
@@ -1,9 +1,9 @@
-import { NODE_HEALTHCHECK_TOLERANCE_IN_SECONDS, thorest } from '../../utils';
 import { InvalidDataType } from '@vechain/sdk-errors';
+import { HttpMethod } from '../../http';
+import { NODE_HEALTHCHECK_TOLERANCE_IN_SECONDS, thorest } from '../../utils';
 import { type CompressedBlockDetail } from '../blocks';
 import { type ThorClient } from '../ThorClient';
 import { type ConnectedPeer } from './types';
-import { HttpMethod } from '../../http';
 
 /**
  * The `NodesModule` class serves as a module for node-related functionality, for example, checking the health of a node.
@@ -20,11 +20,12 @@ class NodesModule {
      *
      * @returns A promise that resolves to the list of connected peers.
      */
-    public async getNodes(): Promise<ConnectedPeer[] | null> {
-        return (await this.thor.httpClient.http(
+    public async getNodes(): Promise<ConnectedPeer[]> {
+        const nodes = (await this.thor.httpClient.http(
             HttpMethod.GET,
             thorest.nodes.get.NODES()
         )) as ConnectedPeer[] | null;
+        return nodes ?? [];
     }
 
     /**


### PR DESCRIPTION
# Description

Closes #1486 

## Type of change

- [x] Refactor of existing code

# How Has This Been Tested?

SDK test suite.

**Test Configuration**:
* Node.js Version: 20.18.0
* Yarn Version: 1.22.19

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code