### PR TITLE
fix: missing explicit `ethers` import

### DIFF
--- a/packages/aws-kms-adapter/package.json
+++ b/packages/aws-kms-adapter/package.json
@@ -41,6 +41,8 @@
     "@aws-sdk/client-kms": "^3.682.0",
     "@vechain/sdk-errors": "1.0.0-rc.2",
     "@vechain/sdk-network": "1.0.0-rc.2",
-    "asn1js": "^3.0.5"
+    "asn1js": "^3.0.5",
+    "ethers": "6.13.4",
+    "viem": "^2.21.19"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,7 @@
     "@scure/bip39": "^1.4.0",
     "@vechain/sdk-errors": "1.0.0-rc.2",
     "@vechain/sdk-logging": "1.0.0-rc.2",
+    "abitype": "^1.0.6",
     "ethers": "6.13.4",
     "fast-json-stable-stringify": "^2.1.0",
     "viem": "^2.21.19"

--- a/packages/ethers-adapter/package.json
+++ b/packages/ethers-adapter/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@vechain/sdk-core": "1.0.0-rc.2",
     "@vechain/sdk-errors": "1.0.0-rc.2",
-    "@vechain/sdk-network": "1.0.0-rc.2"
+    "@vechain/sdk-network": "1.0.0-rc.2",
+    "ethers": "6.13.4"
   }
 }

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -39,7 +39,8 @@
   "dependencies": {
     "@vechain/sdk-errors": "1.0.0-rc.2",
     "@vechain/sdk-ethers-adapter": "1.0.0-rc.2",
-    "@vechain/sdk-network": "1.0.0-rc.2"
+    "@vechain/sdk-network": "1.0.0-rc.2",
+    "ethers": "6.13.4"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-ethers": "^3.0.8"

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -46,6 +46,7 @@
     "@vechain/sdk-logging": "1.0.0-rc.2",
     "@vechain/vebetterdao-contracts": "^4.0.0",
     "abitype": "^1.0.6",
+    "ethers": "6.13.4",
     "isomorphic-ws": "^5.0.0",
     "viem": "^2.21.19",
     "ws": "^8.18.0"


### PR DESCRIPTION
# Description

For the `index.js` bundle there was an issue because an explicit import of `ethers` 6 was missing.

Tested with the `veworld-mobile` repo and it works.

Closes #1506.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

With the SDK test suite. 

Besides that, I have modified the import at  the `veworld-mobile` repo so `package.json` looks like this (**I have both projects at the same level**):
```
    "@vechain/sdk-core": "file:../vechain-sdk-js/packages/core",
    "@vechain/sdk-network": "file:../vechain-sdk-js/packages/network",
```

After this, just run:

1. `yarn install:all`
2. `yarn test`

All tests are passing for me.

**Test Configuration**:
* Node.js Version: 20.18.0
* Yarn Version: 1.22.19

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code