### PR TITLE
issue: 1518 - rpc proxy return value for get uncles by block hash/number by index

### DIFF
--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getUncleByBlockHashAndIndex/eth_getUncleByBlockHashAndIndex.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getUncleByBlockHashAndIndex/eth_getUncleByBlockHashAndIndex.ts
@@ -19,7 +19,7 @@ import { ThorId } from '@vechain/sdk-core';
  */
 const ethGetUncleByBlockHashAndIndex = async (
     params: unknown[]
-): Promise<object> => {
+): Promise<object | null> => {
     // Input validation
     if (
         params.length !== 2 ||
@@ -33,7 +33,7 @@ const ethGetUncleByBlockHashAndIndex = async (
             { params }
         );
 
-    return await Promise.resolve({});
+    return await Promise.resolve(null);
 };
 
 export { ethGetUncleByBlockHashAndIndex };

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_getUncleByBlockNumberAndIndex/eth_getUncleByBlockNumberAndIndex.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_getUncleByBlockNumberAndIndex/eth_getUncleByBlockNumberAndIndex.ts
@@ -19,7 +19,7 @@ import { JSONRPCInvalidParams } from '@vechain/sdk-errors';
  */
 const ethGetUncleByBlockNumberAndIndex = async (
     params: unknown[]
-): Promise<object> => {
+): Promise<object | null> => {
     // Input validation
     if (
         params.length !== 2 ||
@@ -32,7 +32,7 @@ const ethGetUncleByBlockNumberAndIndex = async (
             { params }
         );
 
-    return await Promise.resolve({});
+    return await Promise.resolve(null);
 };
 
 export { ethGetUncleByBlockNumberAndIndex };

--- a/packages/network/src/provider/utils/rpc-mapper/rpc-mapper.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/rpc-mapper.ts
@@ -281,13 +281,13 @@ const RPCMethodsMap = (
 
         [RPC_METHODS.eth_getUncleByBlockHashAndIndex]: async (
             params
-        ): Promise<object> => {
+        ): Promise<object | null> => {
             return await ethGetUncleByBlockHashAndIndex(params);
         },
 
         [RPC_METHODS.eth_getUncleByBlockNumberAndIndex]: async (
             params
-        ): Promise<object> => {
+        ): Promise<object | null> => {
             return await ethGetUncleByBlockNumberAndIndex(params);
         },
 

--- a/packages/network/tests/provider/rpc-mapper/methods/eth_getUncleByBlockHashAndIndex/eth_getUncleByBlockHashAndIndex.testnet.test.ts
+++ b/packages/network/tests/provider/rpc-mapper/methods/eth_getUncleByBlockHashAndIndex/eth_getUncleByBlockHashAndIndex.testnet.test.ts
@@ -41,7 +41,7 @@ describe('RPC Mapper - eth_getUncleByBlockHashAndIndex method tests', () => {
                 '0x0'
             ]);
 
-            expect(uncleBlock).toStrictEqual({});
+            expect(uncleBlock).toStrictEqual(null);
         });
     });
 

--- a/packages/network/tests/provider/rpc-mapper/methods/eth_getUncleByBlockNumberAndIndex/eth_getUncleByBlockNumberAndIndex.testnet.test.ts
+++ b/packages/network/tests/provider/rpc-mapper/methods/eth_getUncleByBlockNumberAndIndex/eth_getUncleByBlockNumberAndIndex.testnet.test.ts
@@ -38,7 +38,7 @@ describe('RPC Mapper - eth_getUncleByBlockNumberAndIndex method tests', () => {
                 RPC_METHODS.eth_getUncleByBlockNumberAndIndex
             ](['latest', '0x0']);
 
-            expect(uncleBlock).toStrictEqual({});
+            expect(uncleBlock).toStrictEqual(null);
         });
     });
 

--- a/packages/rpc-proxy/tests/e2e_rpc_proxy.solo.test.ts
+++ b/packages/rpc-proxy/tests/e2e_rpc_proxy.solo.test.ts
@@ -516,7 +516,7 @@ describe('RPC Proxy endpoints', () => {
             console.log(response.data);
             expect(response.data).toHaveProperty('result');
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            expect(response.data.result).toStrictEqual({});
+            expect(response.data.result).toBeNull();
         });
 
         it('eth_getUncleByBlockNumberAndIndex method call', async () => {
@@ -532,7 +532,7 @@ describe('RPC Proxy endpoints', () => {
             console.log(response.data);
             expect(response.data).toHaveProperty('result');
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            expect(response.data.result).toStrictEqual({});
+            expect(response.data.result).toBeNull();
         });
 
         it('eth_requestAccounts method call', async () => {


### PR DESCRIPTION
# Description

eth_getUncleByBlockNumberAndIndex
eth_getUncleByBlockHashAndIndex

were returning {} instead of null


Fixes #1518 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] rpc unit test
- [x] rpc e2e test

**Test Configuration**:
* Node.js Version:
* Yarn Version:

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code