### PR TITLE
1124 request   restore ability to inject custom fetch instance

### DIFF
--- a/docs/diagrams/architecture/http.md
+++ b/docs/diagrams/architecture/http.md
@@ -1,9 +1,5 @@
 ```mermaid
 classDiagram
-    class SimpleHttpClient {
-        number DEFAULT_TIMEOUT$
-        number timeout;
-    }
     class HttpClient {
         <<interface>>
         string baseUrl
@@ -22,6 +18,11 @@ classDiagram
         Record~string, string~ headers
         Record~string, string~ query
         validateResponse(Record~string, string~ headers)
+    }
+    class SimpleHttpClient {
+        number DEFAULT_TIMEOUT$
+        HeadersInit headers
+        number timeout
     }
     HttpMethod o-- HttpClient
     HttpParams *-- HttpClient

--- a/packages/network/src/http/SimpleHttpClient.ts
+++ b/packages/network/src/http/SimpleHttpClient.ts
@@ -52,7 +52,9 @@ class SimpleHttpClient implements HttpClient {
      * Sends an HTTP GET request to the specified path with optional query parameters.
      *
      * @param {string} path - The endpoint path to which the HTTP GET request is sent.
-     * @param {HttpParams} [params] - Optional query parameters to include in the request.
+     * @param {HttpParams} [params] - Optional parameters for the request,
+     * including query parameters, headers, body, and response validation.
+     * {@link HttpParams.headers} override {@link SimpleHttpClient.headers}.
      * @return {Promise<unknown>} A promise that resolves with the response of the GET request.
      */
     public async get(path: string, params?: HttpParams): Promise<unknown> {
@@ -64,7 +66,9 @@ class SimpleHttpClient implements HttpClient {
      *
      * @param {HttpMethod} method - The HTTP method to use for the request (e.g., GET, POST).
      * @param {string} path - The URL path for the request.
-     * @param {HttpParams} [params] - Optional parameters for the request, including query parameters, headers, body, and response validation.
+     * @param {HttpParams} [params] - Optional parameters for the request,
+     * including query parameters, headers, body, and response validation.
+     * {@link HttpParams.headers} override {@link SimpleHttpClient.headers}.
      * @return {Promise<unknown>} A promise that resolves to the response of the HTTP request.
      * @throws {InvalidHTTPRequest} Throws an error if the HTTP request fails.
      */
@@ -134,7 +138,9 @@ class SimpleHttpClient implements HttpClient {
      * Makes an HTTP POST request to the specified path with optional parameters.
      *
      * @param {string} path - The endpoint to which the POST request is made.
-     * @param {HttpParams} [params] - An optional object containing query parameters or data to be sent with the request.
+     * @param {HttpParams} [params] - Optional parameters for the request,
+     * including query parameters, headers, body, and response validation.
+     * {@link HttpParams.headers} override {@link SimpleHttpClient.headers}.
      * @return {Promise<unknown>} A promise that resolves with the response from the server.
      */
     public async post(path: string, params?: HttpParams): Promise<unknown> {

--- a/packages/network/src/http/SimpleHttpClient.ts
+++ b/packages/network/src/http/SimpleHttpClient.ts
@@ -35,13 +35,13 @@ class SimpleHttpClient implements HttpClient {
      * if not overwritten by the {@link HttpParams} of the method sending the request.
      *
      * @param {string} baseURL - The base URL for HTTP requests.
-     * @param {number} [timeout=SimpleHttpClient.DEFAULT_TIMEOUT] - The timeout duration in milliseconds.
      * @param {HeadersInit} [headers=new Headers()] - The default headers for HTTP requests.
+     * @param {number} [timeout=SimpleHttpClient.DEFAULT_TIMEOUT] - The timeout duration in milliseconds.
      */
     constructor(
         baseURL: string,
-        timeout: number = SimpleHttpClient.DEFAULT_TIMEOUT,
-        headers: HeadersInit = new Headers()
+        headers: HeadersInit = new Headers(),
+        timeout: number = SimpleHttpClient.DEFAULT_TIMEOUT
     ) {
         this.baseURL = baseURL;
         this.timeout = timeout;

--- a/packages/network/src/http/SimpleHttpClient.ts
+++ b/packages/network/src/http/SimpleHttpClient.ts
@@ -20,6 +20,8 @@ class SimpleHttpClient implements HttpClient {
      */
     public readonly baseURL: string;
 
+    public readonly headers: HeadersInit;
+
     /**
      * Return the amount of time in milliseconds before a timeout occurs
      * when requesting with HTTP methods.
@@ -27,17 +29,23 @@ class SimpleHttpClient implements HttpClient {
     public readonly timeout: number;
 
     /**
-     * Constructs an instance of SimpleHttpClient with the given base URL and timeout period.
+     * Constructs an instance of SimpleHttpClient with the given base URL,
+     * timeout period and HTTP headers.
+     * The HTTP headers are used each time this client send a request to the URL,
+     * if not overwritten by the {@link HttpParams} of the method sending the request.
      *
-     * @param {string} baseURL - The base URL for the HTTP client.
-     * @param {number} [timeout=SimpleHttpClient.DEFAULT_TIMEOUT] - The timeout period for requests in milliseconds.
+     * @param {string} baseURL - The base URL for HTTP requests.
+     * @param {number} [timeout=SimpleHttpClient.DEFAULT_TIMEOUT] - The timeout duration in milliseconds.
+     * @param {HeadersInit} [headers=new Headers()] - The default headers for HTTP requests.
      */
     constructor(
         baseURL: string,
-        timeout: number = SimpleHttpClient.DEFAULT_TIMEOUT
+        timeout: number = SimpleHttpClient.DEFAULT_TIMEOUT,
+        headers: HeadersInit = new Headers()
     ) {
         this.baseURL = baseURL;
         this.timeout = timeout;
+        this.headers = headers;
     }
 
     /**
@@ -74,6 +82,12 @@ class SimpleHttpClient implements HttpClient {
             if (params?.query != null) {
                 Object.entries(params.query).forEach(([key, value]) => {
                     url.searchParams.append(key, String(value));
+                });
+            }
+            const headers = new Headers(this.headers);
+            if (params?.headers !== undefined && params?.headers != null) {
+                Object.entries(params.headers).forEach(([key, value]) => {
+                    headers.append(key, String(value));
                 });
             }
             const response = await fetch(url, {

--- a/packages/network/tests/http/SimpleHttpClient.solo.test.ts
+++ b/packages/network/tests/http/SimpleHttpClient.solo.test.ts
@@ -63,7 +63,9 @@ describe('SimpleHttpClient solo tests', () => {
                 query: {},
                 body: {},
                 headers: {
-                    'X-Custom-Header': 'custom-value'
+                    'X-Custom-Header': 'custom-value',
+                    'Cache-Control':
+                        'no-store, no-cache, max-age=0, must-revalidate, proxy-revalidate'
                 },
                 validateResponseHeader: function (
                     headers: Record<string, string>
@@ -107,7 +109,11 @@ describe('SimpleHttpClient solo tests', () => {
      */
     test('timeout test - 100 ms', async () => {
         const timeout = 100; // 100ms timeout
-        const httpClient = new SimpleHttpClient(THOR_SOLO_URL, timeout);
+        const httpClient = new SimpleHttpClient(
+            THOR_SOLO_URL,
+            new Headers(),
+            timeout
+        );
 
         // Create a mock server that delays response
         const mockServer = jest.fn().mockImplementation(async () => {

--- a/packages/network/tests/thor-client/ThorClient.unit.test.ts
+++ b/packages/network/tests/thor-client/ThorClient.unit.test.ts
@@ -4,7 +4,7 @@ import { TESTNET_URL, ThorClient } from '../../src';
 /**
  * ThorClient module tests.
  *
- * @group integration/clients/thor-client
+ * @group unit/clients/thor-client
  */
 describe('ThorClient deprecated methods', () => {
     test('ok <- fromUrl', () => {

--- a/packages/network/tests/thor-client/ThorClient.unit.test.ts
+++ b/packages/network/tests/thor-client/ThorClient.unit.test.ts
@@ -3,6 +3,8 @@ import { TESTNET_URL, ThorClient } from '../../src';
 
 /**
  * ThorClient module tests.
+ *
+ * @group integration/clients/thor-client
  */
 describe('ThorClient deprecated methods', () => {
     test('ok <- fromUrl', () => {

--- a/packages/network/tests/thor-client/ThorClient.unit.test.ts
+++ b/packages/network/tests/thor-client/ThorClient.unit.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from '@jest/globals';
+import { TESTNET_URL, ThorClient } from '../../src';
+
+/**
+ * ThorClient module tests.
+ */
+describe('ThorClient deprecated methods', () => {
+    test('ok <- fromUrl', () => {
+        const expected = ThorClient.at(TESTNET_URL);
+        // eslint-disable-next-line sonarjs/deprecation
+        const actual = ThorClient.fromUrl(TESTNET_URL);
+        expect(actual.httpClient.baseURL).toEqual(expected.httpClient.baseURL);
+    });
+});


### PR DESCRIPTION
# Description

The class `packages/network/src/http/SimpleHttpClient.ts` introduces the possibility to sets headers in the `SimpleHttpClient` constructor.

The headers of built objects are included in every request made through the `http` method, if not overwritten by the `params` argument of the class  `packages/network/src/http/HttpParams.ts`.

This solutions allows to set headers to manage HTTP [cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies) and [control-caching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching).

See the test `'ok <- GET and validate` at `packages/network/tests/http/SimpleHttpClient.solo.test.ts`.

Fixes #1124 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change introduced a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `yarn test:solo`
- [x] `yarn test:unit`

**Test Configuration**:
* Node.js Version: v23.1.0
* Yarn Version: 1.22.22

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code