### PR TITLE
fix: 1560 Transaction.ts allows making of incomplete signed instances

### DIFF
--- a/packages/core/src/transaction/Transaction.ts
+++ b/packages/core/src/transaction/Transaction.ts
@@ -2,7 +2,6 @@ import * as nc_utils from '@noble/curves/abstract/utils';
 import {
     InvalidDataType,
     InvalidSecp256k1PrivateKey,
-    InvalidSecp256k1Signature,
     InvalidTransactionField,
     NotDelegatedTransaction,
     UnavailableTransactionField
@@ -474,13 +473,11 @@ class Transaction {
     }
 
     /**
-     * Creates a new Transaction instance if the provided body and optional
-     * signature are valid.
+     * Creates a new Transaction instance if the provided body is valid.
      *
      * @param {TransactionBody} body - The transaction body to be validated.
-     * @param {Uint8Array} [signature] - Optional signature to be validated.
+     * @param {Uint8Array} [signature] - Optional signature.
      * @return {Transaction} A new Transaction instance if validation is successful.
-     * @throws {InvalidSecp256k1Signature} If the provided signature is invalid.
      * @throws {InvalidTransactionField} If the provided body is invalid.
      */
     public static of(
@@ -488,17 +485,7 @@ class Transaction {
         signature?: Uint8Array
     ): Transaction {
         if (Transaction.isValidBody(body)) {
-            if (
-                signature === undefined ||
-                Transaction.isSignatureValid(body, signature)
-            ) {
-                return new Transaction(body, signature);
-            }
-            throw new InvalidSecp256k1Signature(
-                'Transaction.of',
-                'invalid signature',
-                { signature }
-            );
+            return new Transaction(body, signature);
         }
         throw new InvalidTransactionField('Transaction.of', 'invalid body', {
             fieldName: 'body',


### PR DESCRIPTION
# Description

The `packages/core/src/transaction/Transaction.ts` class allows the making of incomplete signed delegated transaction.

This scenario happens between two delegator and delegates parties running JS in two different computers.
The first party sign the transactions and transmits the array of bytes representing the transaction to the second party.
The second party needs to build the transaction from a byte array and complete the signature process.

Fixes #1560 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change required a documentation update in the code documentation.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test `yarn test:examples`
- [x] Test `yarn test:solo`

**Test Configuration**:
* Node.js Version: v23.1.0
* Yarn Version: 1.22.22

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code