### PR TITLE
fix: move license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 vechain
+Copyright (c) 2025 VeChain
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated LICENSE file with current copyright year (2025)
	- Updated copyright holder name from "vechain" to "VeChain"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->