### PR TITLE
feat(EIP712): allow string `chainId` for `domain`

### DIFF
--- a/packages/aws-kms-adapter/package.json
+++ b/packages/aws-kms-adapter/package.json
@@ -45,6 +45,6 @@
     "@vechain/sdk-network": "2.0.0-beta.1",
     "asn1js": "^3.0.5",
     "ethers": "6.13.5",
-    "viem": "^2.21.54"
+    "viem": "^2.22.7"
   }
 }

--- a/packages/aws-kms-adapter/package.json
+++ b/packages/aws-kms-adapter/package.json
@@ -45,6 +45,6 @@
     "@vechain/sdk-network": "2.0.0-beta.1",
     "asn1js": "^3.0.5",
     "ethers": "6.13.5",
-    "viem": "^2.22.7"
+    "viem": "^2.22.8"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
     "abitype": "^1.0.8",
     "ethers": "6.13.5",
     "fast-json-stable-stringify": "^2.1.0",
-    "viem": "^2.22.7"
+    "viem": "^2.22.8"
   },
   "devDependencies": {
     "bignumber.js": "^9.1.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
     "abitype": "^1.0.8",
     "ethers": "6.13.5",
     "fast-json-stable-stringify": "^2.1.0",
-    "viem": "^2.21.54"
+    "viem": "^2.22.7"
   },
   "devDependencies": {
     "bignumber.js": "^9.1.2",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -49,7 +49,7 @@
     "abitype": "^1.0.8",
     "ethers": "6.13.5",
     "isomorphic-ws": "^5.0.0",
-    "viem": "^2.22.7",
+    "viem": "^2.22.8",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -49,7 +49,7 @@
     "abitype": "^1.0.8",
     "ethers": "6.13.5",
     "isomorphic-ws": "^5.0.0",
-    "viem": "^2.21.54",
+    "viem": "^2.22.7",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/packages/network/src/signer/signers/types.d.ts
+++ b/packages/network/src/signer/signers/types.d.ts
@@ -20,7 +20,10 @@ type AvailableVeChainProviders = VeChainProvider | HardhatVeChainProvider;
  * EIP-712 types in case we change the provider (viem as of now)
  */
 
-type TypedDataDomain = viemTypedDataDomain;
+type TypedDataDomain = Omit<viemTypedDataDomain, 'chainId'> & {
+    chainId: number | bigint | string | undefined;
+};
+
 type TypedDataParameter = viemTypedDataParameter;
 
 /**

--- a/packages/network/src/signer/signers/types.d.ts
+++ b/packages/network/src/signer/signers/types.d.ts
@@ -1,7 +1,7 @@
 import { type TransactionClause } from '@vechain/sdk-core';
 import type {
-    TypedDataDomain as viemTypedDataDomain,
-    TypedDataParameter as viemTypedDataParameter
+    TypedDataDomain as ViemTypedDataDomain,
+    TypedDataParameter as ViemTypedDataParameter
 } from 'viem';
 import {
     type HardhatVeChainProvider,
@@ -20,11 +20,11 @@ type AvailableVeChainProviders = VeChainProvider | HardhatVeChainProvider;
  * EIP-712 types in case we change the provider (viem as of now)
  */
 
-type TypedDataDomain = Omit<viemTypedDataDomain, 'chainId'> & {
+type TypedDataDomain = Omit<ViemTypedDataDomain, 'chainId'> & {
     chainId: number | bigint | string | undefined;
 };
 
-type TypedDataParameter = viemTypedDataParameter;
+type TypedDataParameter = ViemTypedDataParameter;
 
 /**
  * Type for transaction input

--- a/packages/network/src/signer/signers/vechain-abstract-signer/vechain-abstract-signer.ts
+++ b/packages/network/src/signer/signers/vechain-abstract-signer/vechain-abstract-signer.ts
@@ -426,9 +426,16 @@ abstract class VeChainAbstractSigner implements VeChainSigner {
         primaryType?: string
     ): Promise<string> {
         try {
+            const parsedDomain = {
+                ...domain,
+                chainId:
+                    typeof domain.chainId === 'string'
+                        ? BigInt(domain.chainId)
+                        : domain.chainId
+            };
             const payload = Hex.of(
                 hashTypedData({
-                    domain,
+                    domain: parsedDomain,
                     types,
                     primaryType: primaryType ?? this.deducePrimaryType(types), // Deduce the primary type if not provided
                     message

--- a/packages/network/tests/signer/signers/vechain-private-key-signer/vechain-private-key-signer.unit.test.ts
+++ b/packages/network/tests/signer/signers/vechain-private-key-signer/vechain-private-key-signer.unit.test.ts
@@ -361,6 +361,19 @@ describe('VeChain base signer tests', () => {
                     eip712TestCases.valid.data
                 );
             expect(actualWithoutPrimaryType).toBe(expected);
+
+            // Using VeChain chainId as string and bigint
+            const expectedVeChain = await new Wallet(
+                eip712TestCases.valid.privateKey
+            ).signTypedData(
+                {
+                    ...eip712TestCases.valid.domain,
+                    chainId:
+                        '1176455790972829965191905223412607679856028701100105089447013101863'
+                },
+                eip712TestCases.valid.types,
+                eip712TestCases.valid.data
+            );
             const actualWithStringChainId =
                 await privateKeySigner.signTypedData(
                     {
@@ -372,7 +385,7 @@ describe('VeChain base signer tests', () => {
                     eip712TestCases.valid.data,
                     eip712TestCases.valid.primaryType
                 );
-            expect(actualWithStringChainId).toBe(expected);
+            expect(actualWithStringChainId).toBe(expectedVeChain);
             const actualWithBigintChainId =
                 await privateKeySigner.signTypedData(
                     {
@@ -384,7 +397,7 @@ describe('VeChain base signer tests', () => {
                     eip712TestCases.valid.data,
                     eip712TestCases.valid.primaryType
                 );
-            expect(actualWithBigintChainId).toBe(expected);
+            expect(actualWithBigintChainId).toBe(expectedVeChain);
         });
     });
 });

--- a/packages/network/tests/signer/signers/vechain-private-key-signer/vechain-private-key-signer.unit.test.ts
+++ b/packages/network/tests/signer/signers/vechain-private-key-signer/vechain-private-key-signer.unit.test.ts
@@ -363,13 +363,14 @@ describe('VeChain base signer tests', () => {
             expect(actualWithoutPrimaryType).toBe(expected);
 
             // Using VeChain chainId as string and bigint
+            const vechainChainId =
+                '1176455790972829965191905223412607679856028701100105089447013101863';
             const expectedVeChain = await new Wallet(
                 eip712TestCases.valid.privateKey
             ).signTypedData(
                 {
                     ...eip712TestCases.valid.domain,
-                    chainId:
-                        '1176455790972829965191905223412607679856028701100105089447013101863'
+                    chainId: vechainChainId
                 },
                 eip712TestCases.valid.types,
                 eip712TestCases.valid.data
@@ -378,8 +379,7 @@ describe('VeChain base signer tests', () => {
                 await privateKeySigner.signTypedData(
                     {
                         ...eip712TestCases.valid.domain,
-                        chainId:
-                            '1176455790972829965191905223412607679856028701100105089447013101863'
+                        chainId: vechainChainId
                     },
                     eip712TestCases.valid.types,
                     eip712TestCases.valid.data,
@@ -390,8 +390,7 @@ describe('VeChain base signer tests', () => {
                 await privateKeySigner.signTypedData(
                     {
                         ...eip712TestCases.valid.domain,
-                        chainId:
-                            1176455790972829965191905223412607679856028701100105089447013101863n
+                        chainId: BigInt(vechainChainId)
                     },
                     eip712TestCases.valid.types,
                     eip712TestCases.valid.data,

--- a/packages/network/tests/signer/signers/vechain-private-key-signer/vechain-private-key-signer.unit.test.ts
+++ b/packages/network/tests/signer/signers/vechain-private-key-signer/vechain-private-key-signer.unit.test.ts
@@ -361,6 +361,30 @@ describe('VeChain base signer tests', () => {
                     eip712TestCases.valid.data
                 );
             expect(actualWithoutPrimaryType).toBe(expected);
+            const actualWithStringChainId =
+                await privateKeySigner.signTypedData(
+                    {
+                        ...eip712TestCases.valid.domain,
+                        chainId:
+                            '1176455790972829965191905223412607679856028701100105089447013101863'
+                    },
+                    eip712TestCases.valid.types,
+                    eip712TestCases.valid.data,
+                    eip712TestCases.valid.primaryType
+                );
+            expect(actualWithStringChainId).toBe(expected);
+            const actualWithBigintChainId =
+                await privateKeySigner.signTypedData(
+                    {
+                        ...eip712TestCases.valid.domain,
+                        chainId:
+                            1176455790972829965191905223412607679856028701100105089447013101863n
+                    },
+                    eip712TestCases.valid.types,
+                    eip712TestCases.valid.data,
+                    eip712TestCases.valid.primaryType
+                );
+            expect(actualWithBigintChainId).toBe(expected);
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11559,10 +11559,10 @@ outvariant@^1.4.0, outvariant@^1.4.3:
   resolved "https://registry.yarnpkg.com/outvariant/-/outvariant-1.4.3.tgz#221c1bfc093e8fec7075497e7799fdbf43d14873"
   integrity sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==
 
-ox@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.npmjs.org/ox/-/ox-0.1.2.tgz#0f791be2ccabeaf4928e6d423498fe1c8094e560"
-  integrity sha512-ak/8K0Rtphg9vnRJlbOdaX9R7cmxD2MiSthjWGaQdMk3D7hrAlDoM+6Lxn7hN52Za3vrXfZ7enfke/5WjolDww==
+ox@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.npmjs.org/ox/-/ox-0.6.0.tgz#ba8f89d68b5e8afe717c8a947ffacc0669ea155d"
+  integrity sha512-blUzTLidvUlshv0O02CnLFqBLidNzPoAZdIth894avUAotTuWziznv6IENv5idRuOSSP3dH8WzcYw84zVdu0Aw==
   dependencies:
     "@adraffy/ens-normalize" "^1.10.1"
     "@noble/curves" "^1.6.0"
@@ -14391,10 +14391,10 @@ vfile@^6.0.0:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
 
-viem@^2.21.54:
-  version "2.21.54"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-2.21.54.tgz#76d6f86ab8809078f1ac140ac1a2beadbc86b9f6"
-  integrity sha512-G9mmtbua3UtnVY9BqAtWdNp+3AO+oWhD0B9KaEsZb6gcrOWgmA4rz02yqEMg+qW9m6KgKGie7q3zcHqJIw6AqA==
+viem@^2.22.7:
+  version "2.22.7"
+  resolved "https://registry.npmjs.org/viem/-/viem-2.22.7.tgz#70b92859a3401fa056f86a13c8d2befffde8bb2f"
+  integrity sha512-heNQKOqpgAhdvu5xBAgWCqNVDkC6FfQyQ63+JVSUomOzmnbHAO1FKf4/JRe/s1McU1F4HkgjytOunQS9mbBD2g==
   dependencies:
     "@noble/curves" "1.7.0"
     "@noble/hashes" "1.6.1"
@@ -14402,7 +14402,7 @@ viem@^2.21.54:
     "@scure/bip39" "1.5.0"
     abitype "1.0.7"
     isows "1.0.6"
-    ox "0.1.2"
+    ox "0.6.0"
     webauthn-p256 "0.0.10"
     ws "8.18.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14391,10 +14391,10 @@ vfile@^6.0.0:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
 
-viem@^2.22.7:
-  version "2.22.7"
-  resolved "https://registry.npmjs.org/viem/-/viem-2.22.7.tgz#70b92859a3401fa056f86a13c8d2befffde8bb2f"
-  integrity sha512-heNQKOqpgAhdvu5xBAgWCqNVDkC6FfQyQ63+JVSUomOzmnbHAO1FKf4/JRe/s1McU1F4HkgjytOunQS9mbBD2g==
+viem@^2.22.8:
+  version "2.22.8"
+  resolved "https://registry.npmjs.org/viem/-/viem-2.22.8.tgz#fbc51215133066b89730e9a2aa2c7c0cb975a8e8"
+  integrity sha512-iB3PW/a/qzpYbpjo3R662u6a/zo6piZHez/N/bOC25C79FYXBCs8mQDqwiHk3FYErUhS4KVZLabKV9zGMd+EgQ==
   dependencies:
     "@noble/curves" "1.7.0"
     "@noble/hashes" "1.6.1"


### PR DESCRIPTION
# Description

Allows the usage of a string for chainId since currently there are some users (like veworld) using it that way.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Using the full test suite

**Test Configuration**:
* Node.js Version: 20.18.0
* Yarn Version: 1.22.22

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependencies**
	- Updated `viem` library version from `^2.21.54` to `^2.22.8` across multiple packages (`aws-kms-adapter`, `core`, `network`)

- **Type Changes**
	- Modified `TypedDataDomain` type to support more flexible `chainId` representation (number, bigint, string, or undefined)

- **Improvements**
	- Enhanced `signTypedData` method to handle `chainId` conversion more robustly
	- Added test cases to verify `chainId` handling in different formats
<!-- end of auto-generated comment: release notes by coderabbit.ai -->