### PR TITLE
refactor: create HexUInt32 class

### DIFF
--- a/packages/core/src/vcdm/HexUInt32.ts
+++ b/packages/core/src/vcdm/HexUInt32.ts
@@ -1,0 +1,54 @@
+import { InvalidDataType } from '@vechain/sdk-errors';
+import { type HexInt } from './HexInt';
+import { HexUInt } from './HexUInt';
+
+/**
+ * Represents a 32-byte hexadecimal unsigned integer.
+ *
+ * @extends HexUInt
+ */
+class HexUInt32 extends HexUInt {
+    /**
+     * Expected byte length.
+     * @type {number}
+     */
+    private static readonly BYTE_LENGTH = 32;
+
+    /**
+     * Ensures the hexadecimal string representation is 32 bytes long.
+     * @param {string} hexString - The hexadecimal string to validate.
+     * @returns {string} The 32 bytes long hexadecimal string.
+     */
+    private static convertTo32Bytes(hexString: string): string {
+        const nonPrefixedHex = hexString.replace(/^0x/, '');
+
+        return nonPrefixedHex.padStart(this.BYTE_LENGTH * 2, '0');
+    }
+
+    /**
+     * Creates a HexUInt32 instance with enforced 32 bytes length.
+     * @param {bigint | number | string | Uint8Array | HexInt} exp - The expression to convert.
+     * @returns {HexUInt32} The HexUInt32 object representing the given expression.
+     * @throws {InvalidDataType} If the value is not a valid 32-byte hex string.
+     */
+    public static of(
+        exp: bigint | number | string | Uint8Array | HexInt
+    ): HexUInt32 {
+        try {
+            const hexUInt = HexUInt.of(exp);
+
+            const hexDigits = this.convertTo32Bytes(hexUInt.toString());
+
+            return new HexUInt32(hexUInt.sign, hexDigits);
+        } catch (e) {
+            throw new InvalidDataType(
+                'HexUInt32.of',
+                'not a 32 bytes long hexadecimal positive integer expression',
+                { exp: `${exp}`, e },
+                e
+            );
+        }
+    }
+}
+
+export { HexUInt32 };

--- a/packages/core/src/vcdm/HexUInt32.ts
+++ b/packages/core/src/vcdm/HexUInt32.ts
@@ -15,6 +15,26 @@ class HexUInt32 extends HexUInt {
     private static readonly BYTE_LENGTH = 32;
 
     /**
+     * Regular expression for matching 32 bytes hexadecimal strings.
+     * An empty input is represented as a empty digits.
+     *
+     * @type {RegExp}
+     */
+    private static readonly REGEX_HEXUINT32: RegExp = /^(0x)?[0-9a-f]{64}$/i;
+
+    /**
+     * Checks if the given string expression is a valid 32 bytes unsigned hexadecimal value.
+     *
+     * @param {string} exp - The string representation of a hexadecimal value.
+     *
+     * @return {boolean} - True if the expression is a valid 32 bytes unsigned hexadecimal value, case-insensitive,
+     * optionally prefixed with `0x`; false otherwise.
+     */
+    public static isValid(exp: string): boolean {
+        return HexUInt32.REGEX_HEXUINT32.test(exp);
+    }
+
+    /**
      * Ensures the hexadecimal string representation is 32 bytes long.
      * @param {string} hexString - The hexadecimal string to validate.
      * @returns {string} The 32 bytes long hexadecimal string.

--- a/packages/core/tests/vcdm/HexUInt32.unit.test.ts
+++ b/packages/core/tests/vcdm/HexUInt32.unit.test.ts
@@ -19,6 +19,13 @@ describe('HexUInt32 class tests', () => {
             expect(hexUInt32.toString()).toEqual(expectedHexUInt32);
         });
 
+        test('Checks if the provided expression is a valid 32 bytes unsigned hexadecimal value', () => {
+            const expression =
+                '0x0000000000000000000000000000000000000000000000000000000000caffee';
+
+            expect(HexUInt32.isValid(expression)).toBeTruthy();
+        });
+
         test('Throw an error if the provided argument is not an unsigned expression', () => {
             const exp = '-0xnotUnsigned';
             expect(() => HexUInt32.of(exp)).toThrow(InvalidDataType);

--- a/packages/core/tests/vcdm/HexUInt32.unit.test.ts
+++ b/packages/core/tests/vcdm/HexUInt32.unit.test.ts
@@ -31,6 +31,7 @@ describe('HexUInt32 class tests', () => {
             const ofBytes = HexUInt32.of(Uint8Array.of(255));
             const ofHex = HexUInt32.of('0xff');
             const ofNumber = HexUInt32.of(255);
+            expect(ofBigInt.toString()).toHaveLength(66);
             expect(ofBigInt.isEqual(ofBytes)).toBeTruthy();
             expect(ofBytes.isEqual(ofHex)).toBeTruthy();
             expect(ofHex.isEqual(ofNumber)).toBeTruthy();

--- a/packages/core/tests/vcdm/HexUInt32.unit.test.ts
+++ b/packages/core/tests/vcdm/HexUInt32.unit.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from '@jest/globals';
+import { InvalidDataType } from '@vechain/sdk-errors';
+import { HexUInt32 } from '../../src/vcdm/HexUInt32';
+
+/**
+ * Test HexUInt32 class.
+ * @group unit/vcdm
+ */
+describe('HexUInt32 class tests', () => {
+    describe('Construction tests', () => {
+        test('Return an HexUInt32 instance of the provided expression', () => {
+            const expression = '0xcaffee';
+            const expectedHexUInt32 =
+                '0x0000000000000000000000000000000000000000000000000000000000caffee';
+
+            const hexUInt32 = HexUInt32.of(expression);
+
+            expect(hexUInt32).toBeInstanceOf(HexUInt32);
+            expect(hexUInt32.toString()).toEqual(expectedHexUInt32);
+        });
+
+        test('Throw an error if the provided argument is not an unsigned expression', () => {
+            const exp = '-0xnotUnsigned';
+            expect(() => HexUInt32.of(exp)).toThrow(InvalidDataType);
+        });
+    });
+
+    describe('Polymorphism equivalence', () => {
+        test('Equal for bigint, bytes, hex expression, number', () => {
+            const ofBigInt = HexUInt32.of(255n);
+            const ofBytes = HexUInt32.of(Uint8Array.of(255));
+            const ofHex = HexUInt32.of('0xff');
+            const ofNumber = HexUInt32.of(255);
+            expect(ofBigInt.isEqual(ofBytes)).toBeTruthy();
+            expect(ofBytes.isEqual(ofHex)).toBeTruthy();
+            expect(ofHex.isEqual(ofNumber)).toBeTruthy();
+        });
+    });
+});


### PR DESCRIPTION
# Description

Extent hexUint class to a class enforcing lenght (hexUint 32). Then extend in subclasses aiming to replace thorId with the new classes representing the new semantic (blockId vs txId vs ....)

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests

**Test Configuration**:
* Node.js Version:
* Yarn Version:

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code