### PR TITLE
1658 bnc - part 1

### DIFF
--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -203,22 +203,21 @@ You can specify revisions (`best` or `finalized`) for read functions, similar to
 
 ## Delegating a Contract Call
 
-VeChain supports delegated contract calls where fees are paid by the delegator.
+VeChain supports delegated contract calls where fees are paid by the gas-payer.
 
 ```typescript { name=contract-delegation-erc20, category=example }
 const thorSoloClient = ThorClient.at(THOR_SOLO_URL);
 const provider = new VeChainProvider(
     thorSoloClient,
     new ProviderInternalBaseWallet([deployerAccount], {
+        // The term `delegator` will be deprecated soon and renamed `gasPayer`.
         delegator: {
-            delegatorPrivateKey: delegatorAccount.privateKey
+            delegatorPrivateKey: gasPayerAccount.privateKey
         }
     }),
     true
 );
-const signer = (await provider.getSigner(
-    deployerAccount.address
-)) as VeChainSigner;
+const signer = await provider.getSigner(deployerAccount.address);
 
 // Defining a function for deploying the ERC20 contract
 const setupERC20Contract = async (): Promise<Contract<typeof ERC20_ABI>> => {
@@ -245,8 +244,7 @@ const transferResult = await contract.transact.transfer(
 );
 
 // Wait for the transfer transaction to complete and obtain its receipt
-const transactionReceiptTransfer =
-    (await transferResult.wait()) as TransactionReceipt;
+const transactionReceiptTransfer = await transferResult.wait();
 
 // Asserting that the transaction has not been reverted
 expect(transactionReceiptTransfer.reverted).toEqual(false);

--- a/docs/examples/transactions/fee-delegation.ts
+++ b/docs/examples/transactions/fee-delegation.ts
@@ -61,17 +61,17 @@ const body: TransactionBody = {
 // 4 - Create private keys of sender and delegate
 
 const nodeDelegate = HDKey.fromMnemonic(Mnemonic.of());
-const delegatorPrivateKey = nodeDelegate.privateKey;
+const gasPayerPrivateKey = nodeDelegate.privateKey;
 
 // 5 - Get address of delegate
 
-const delegatorAddress = Address.ofPublicKey(nodeDelegate.publicKey).toString();
+const gasPayerAddress = Address.ofPublicKey(nodeDelegate.publicKey).toString();
 
 // 6 - Sign transaction as sender and delegate
 
 const signedTransaction = Transaction.of(body).signAsSenderAndGasPayer(
     HexUInt.of(senderAccount.privateKey).bytes,
-    HexUInt.of(delegatorPrivateKey).bytes
+    HexUInt.of(gasPayerPrivateKey).bytes
 );
 
 // 7 - Encode transaction
@@ -85,4 +85,4 @@ const decodedTx = Transaction.decode(encodedRaw, true);
 // END_SNIPPET: FeeDelegationSnippet
 
 expect(decodedTx.isDelegated).toBeTruthy();
-expect(decodedTx.gasPayer.toString()).toBe(delegatorAddress);
+expect(decodedTx.gasPayer.toString()).toBe(gasPayerAddress);

--- a/docs/examples/transactions/full-flow-delegator-private-key.ts
+++ b/docs/examples/transactions/full-flow-delegator-private-key.ts
@@ -29,8 +29,8 @@ const senderAccount: { privateKey: string; address: string } = {
     address: '0x7a28e7361fd10f4f058f9fefc77544349ecff5d6'
 };
 
-// Delegator account with private key
-const delegatorAccount: { privateKey: string; address: string } = {
+// Gas-payer account with private key
+const gasPayerAccount: { privateKey: string; address: string } = {
     privateKey:
         '521b7793c6eb27d137b617627c6b85d57c0aa303380e9ca4e30a30302fbc6676',
     address: '0x062F167A905C1484DE7e75B88EDC7439f82117DE'
@@ -50,8 +50,9 @@ const providerWithDelegationEnabled = new VeChainProvider(
             }
         ],
         {
+            // The term `delegator` will be deprecated soon and renamed `gasPayer`.
             delegator: {
-                delegatorPrivateKey: delegatorAccount.privateKey
+                delegatorPrivateKey: gasPayerAccount.privateKey
             }
         }
     ),
@@ -119,7 +120,7 @@ const txReceipt = await thorSoloClient.transactions.waitForTransaction(
 // Check the signed transaction
 expect(delegatedSigned.isSigned).toEqual(true);
 expect(delegatedSigned.isDelegated).toEqual(true);
-expect(delegatedSigned.gasPayer.toString()).toEqual(delegatorAccount.address);
+expect(delegatedSigned.gasPayer.toString()).toEqual(gasPayerAccount.address);
 
 // Check the transaction receipt
 expect(txReceipt).toBeDefined();

--- a/docs/examples/transactions/full-flow-delegator-url.ts
+++ b/docs/examples/transactions/full-flow-delegator-url.ts
@@ -35,8 +35,8 @@ const senderAccount: {
     address: '0x571E3E1fBE342891778151f037967E107fb89bd0'
 };
 
-// Delegator account with private key
-const delegatorAccount = {
+// Gas-payer account with private key
+const gasPayerAccount = {
     URL: 'https://sponsor-testnet.vechain.energy/by/269'
 };
 
@@ -54,8 +54,9 @@ const providerWithDelegationEnabled = new VeChainProvider(
             }
         ],
         {
+            // The term `delegator` will be deprecated soon and renamed `gasPayer`.
             delegator: {
-                delegatorUrl: delegatorAccount.URL
+                delegatorUrl: gasPayerAccount.URL
             }
         }
     ),
@@ -123,7 +124,7 @@ const txReceipt = await thorClient.transactions.waitForTransaction(
 // Check the signed transaction
 expect(delegatedSigned.isSigned).toEqual(true);
 expect(delegatedSigned.isDelegated).toEqual(true);
-// expect(signedTx.delegator).toEqual(delegatorAccount.address); ---
+// expect(signedTx.delegator).toEqual(gasPayerAccount.address); ---
 
 // Check the transaction receipt
 expect(txReceipt).toBeDefined();

--- a/docs/templates/contracts.md
+++ b/docs/templates/contracts.md
@@ -70,6 +70,6 @@ You can specify revisions (`best` or `finalized`) for read functions, similar to
 
 ## Delegating a Contract Call
 
-VeChain supports delegated contract calls where fees are paid by the delegator.
+VeChain supports delegated contract calls where fees are paid by the gas-payer.
 
 [ERC20FunctionCallDelegatedSnippet](examples/contracts/contract-delegation-ERC20.ts)

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -164,17 +164,17 @@ const body: TransactionBody = {
 // 4 - Create private keys of sender and delegate
 
 const nodeDelegate = HDKey.fromMnemonic(Mnemonic.of());
-const delegatorPrivateKey = nodeDelegate.privateKey;
+const gasPayerPrivateKey = nodeDelegate.privateKey;
 
 // 5 - Get address of delegate
 
-const delegatorAddress = Address.ofPublicKey(nodeDelegate.publicKey).toString();
+const gasPayerAddress = Address.ofPublicKey(nodeDelegate.publicKey).toString();
 
 // 6 - Sign transaction as sender and delegate
 
 const signedTransaction = Transaction.of(body).signAsSenderAndGasPayer(
     HexUInt.of(senderAccount.privateKey).bytes,
-    HexUInt.of(delegatorPrivateKey).bytes
+    HexUInt.of(gasPayerPrivateKey).bytes
 );
 
 // 7 - Encode transaction
@@ -464,8 +464,8 @@ const senderAccount: { privateKey: string; address: string } = {
     address: '0x7a28e7361fd10f4f058f9fefc77544349ecff5d6'
 };
 
-// Delegator account with private key
-const delegatorAccount: { privateKey: string; address: string } = {
+// Gas-payer account with private key
+const gasPayerAccount: { privateKey: string; address: string } = {
     privateKey:
         '521b7793c6eb27d137b617627c6b85d57c0aa303380e9ca4e30a30302fbc6676',
     address: '0x062F167A905C1484DE7e75B88EDC7439f82117DE'
@@ -485,8 +485,9 @@ const providerWithDelegationEnabled = new VeChainProvider(
             }
         ],
         {
+            // The term `delegator` will be deprecated soon and renamed `gasPayer`.
             delegator: {
-                delegatorPrivateKey: delegatorAccount.privateKey
+                delegatorPrivateKey: gasPayerAccount.privateKey
             }
         }
     ),
@@ -571,8 +572,8 @@ const senderAccount: {
     address: '0x571E3E1fBE342891778151f037967E107fb89bd0'
 };
 
-// Delegator account with private key
-const delegatorAccount = {
+// Gas-payer account with private key
+const gasPayerAccount = {
     URL: 'https://sponsor-testnet.vechain.energy/by/269'
 };
 
@@ -590,8 +591,9 @@ const providerWithDelegationEnabled = new VeChainProvider(
             }
         ],
         {
+            // The term `delegator` will be deprecated soon and renamed `gasPayer`.
             delegator: {
-                delegatorUrl: delegatorAccount.URL
+                delegatorUrl: gasPayerAccount.URL
             }
         }
     ),

--- a/packages/core/tests/transaction/Transaction.unit.test.ts
+++ b/packages/core/tests/transaction/Transaction.unit.test.ts
@@ -654,7 +654,7 @@ describe('Transaction class tests', () => {
     });
 
     describe('sign method tests', () => {
-        test('signature <- undelegated', () => {
+        test('signature <- undelegated tx', () => {
             const actual = Transaction.of(
                 TransactionFixture.undelegated.body
             ).sign(SignerFix.privateKey);
@@ -662,7 +662,7 @@ describe('Transaction class tests', () => {
             expect(actual.signature?.length).toBe(Secp256k1.SIGNATURE_LENGTH);
         });
 
-        test('Throw <- delegated', () => {
+        test('Throw <- delegated tx', () => {
             expect(() =>
                 Transaction.of(TransactionFixture.delegated.body).sign(
                     SignerFix.privateKey
@@ -679,8 +679,8 @@ describe('Transaction class tests', () => {
         });
     });
 
-    describe('signAsDelegator method tests', () => {
-        test('signature (complete) <- delegator', () => {
+    describe('signAsGasPayer method tests', () => {
+        test('signature (complete) <- delegated tx', () => {
             const expected = Transaction.of(
                 TransactionFixture.delegated.body
             ).signAsSenderAndGasPayer(
@@ -698,7 +698,7 @@ describe('Transaction class tests', () => {
             expect(actual.signature).toEqual(expected.signature);
         });
 
-        test('Throw <- undelegated', () => {
+        test('Throw <- undelegated tx', () => {
             expect(() => {
                 Transaction.of(TransactionFixture.undelegated.body)
                     .sign(SignerFix.privateKey)
@@ -720,7 +720,7 @@ describe('Transaction class tests', () => {
             }).toThrowError(InvalidTransactionField);
         });
 
-        test('Throw <- invalid private keys - delegator', () => {
+        test('Throw <- invalid private keys - delegated tx', () => {
             expect(() =>
                 Transaction.of(
                     TransactionFixture.undelegated.body
@@ -731,7 +731,7 @@ describe('Transaction class tests', () => {
         });
     });
 
-    describe('signForDelegator method tests', () => {
+    describe('signAsSender method tests', () => {
         test('signature (incomplete) <- signed', () => {
             const expected = Transaction.of(
                 TransactionFixture.delegated.body
@@ -743,14 +743,14 @@ describe('Transaction class tests', () => {
                 TransactionFixture.delegated.body
             ).signAsSender(SignerFix.privateKey);
             expect(actual.signature).toBeDefined(); // The signer's signature exists, but...
-            // ... the delegator signature is missing, hence...
+            // ... the gasPayer signature is missing, hence...
             expect(actual.isSigned).toBe(false); // ... the signature is incomplete.
             expect(actual.signature).toEqual(
                 expected.signature?.slice(0, actual.signature?.length)
             );
         });
 
-        test('Throw <- undelegated', () => {
+        test('Throw <- undelegated tx', () => {
             expect(() =>
                 Transaction.of(
                     TransactionFixture.undelegated.body
@@ -769,8 +769,8 @@ describe('Transaction class tests', () => {
         });
     });
 
-    describe('signWithDelegator method tests', () => {
-        test('signature <- delegated', () => {
+    describe('signAsSenderAndGasPayer method tests', () => {
+        test('signature <- delegated tx', () => {
             const actual = Transaction.of(
                 TransactionFixture.delegated.body
             ).signAsSenderAndGasPayer(
@@ -787,7 +787,7 @@ describe('Transaction class tests', () => {
             expect(actual.gasPayer.isEqual(DelegatorFix.address)).toBe(true);
         });
 
-        test('Throw <- undelegated', () => {
+        test('Throw <- undelegated tx', () => {
             expect(() =>
                 Transaction.of(
                     TransactionFixture.undelegated.body
@@ -809,7 +809,7 @@ describe('Transaction class tests', () => {
             ).toThrowError(InvalidSecp256k1PrivateKey);
         });
 
-        test('Throw <- invalid private keys - delegator', () => {
+        test('Throw <- invalid private keys - delegated tx', () => {
             expect(() => {
                 Transaction.of(
                     TransactionFixture.undelegated.body

--- a/packages/core/tests/transaction/Transaction.unit.test.ts
+++ b/packages/core/tests/transaction/Transaction.unit.test.ts
@@ -701,7 +701,7 @@ describe('Transaction class tests', () => {
             }).toThrowError(NotDelegatedTransaction);
         });
 
-        test('Throw <- unsigned', () => {
+        test('Throw <- unsigned tx', () => {
             expect(() => {
                 Transaction.of(
                     TransactionFixture.delegated.body

--- a/packages/core/tests/transaction/Transaction.unit.test.ts
+++ b/packages/core/tests/transaction/Transaction.unit.test.ts
@@ -17,13 +17,13 @@ import {
     VTHO
 } from '../../src';
 
-const DelegatorPrivateKeyFix = HexUInt.of(
+const GasPayerPrivateKeyFix = HexUInt.of(
     '40de805e918403683fb9a6081c3fba072cdc5c88232c62a9509165122488dab7'
 ).bytes;
 
-const DelegatorFix = {
-    privateKey: DelegatorPrivateKeyFix,
-    address: Address.ofPrivateKey(DelegatorPrivateKeyFix)
+const GasPayerFix = {
+    privateKey: GasPayerPrivateKeyFix,
+    address: Address.ofPrivateKey(GasPayerPrivateKeyFix)
 };
 
 const SignerPrivateKeyFix = HexUInt.of(
@@ -233,7 +233,7 @@ describe('Transaction class tests', () => {
                 const signer = Address.ofPrivateKey(SignerFix.privateKey);
                 const actual = signed.signAsGasPayer(
                     signer,
-                    DelegatorFix.privateKey
+                    GasPayerFix.privateKey
                 );
                 expect(actual.isDelegated).toBe(true);
                 expect(actual.isSigned).toBe(true);
@@ -276,7 +276,7 @@ describe('Transaction class tests', () => {
                     expected.body
                 ).signAsSenderAndGasPayer(
                     SignerFix.privateKey,
-                    DelegatorFix.privateKey
+                    GasPayerFix.privateKey
                 );
                 expect(actual).toBeInstanceOf(Transaction);
                 expect(actual.signature).toBeDefined();
@@ -291,9 +291,7 @@ describe('Transaction class tests', () => {
                         .isEqual(expected.transactionHash)
                 ).toBe(true);
                 expect(actual.origin.isEqual(SignerFix.address)).toBe(true);
-                expect(actual.gasPayer.isEqual(DelegatorFix.address)).toBe(
-                    true
-                );
+                expect(actual.gasPayer.isEqual(GasPayerFix.address)).toBe(true);
                 expect(actual.id.isEqual(expected.signedTransactionId)).toBe(
                     true
                 );
@@ -306,7 +304,7 @@ describe('Transaction class tests', () => {
                     expected.body
                 ).signAsSenderAndGasPayer(
                     SignerFix.privateKey,
-                    DelegatorFix.privateKey
+                    GasPayerFix.privateKey
                 );
                 expect(actual).toBeInstanceOf(Transaction);
                 expect(actual.signature).toBeDefined();
@@ -321,9 +319,7 @@ describe('Transaction class tests', () => {
                         .isEqual(expected.transactionHash)
                 ).toBe(true);
                 expect(actual.origin.isEqual(SignerFix.address)).toBe(true);
-                expect(actual.gasPayer.isEqual(DelegatorFix.address)).toBe(
-                    true
-                );
+                expect(actual.gasPayer.isEqual(GasPayerFix.address)).toBe(true);
                 expect(actual.id.isEqual(expected.signedTransactionId)).toBe(
                     true
                 );
@@ -425,9 +421,7 @@ describe('Transaction class tests', () => {
                 expect(actual.origin).toBeDefined();
                 expect(actual.origin.isEqual(SignerFix.address)).toBe(true);
                 expect(actual.gasPayer).toBeDefined();
-                expect(actual.gasPayer.isEqual(DelegatorFix.address)).toBe(
-                    true
-                );
+                expect(actual.gasPayer.isEqual(GasPayerFix.address)).toBe(true);
                 expect(actual.isDelegated).toBe(true);
                 expect(actual.id).toBeDefined();
                 expect(actual.isSigned).toBe(true);
@@ -477,9 +471,7 @@ describe('Transaction class tests', () => {
                 expect(actual.origin).toBeDefined();
                 expect(actual.origin.isEqual(SignerFix.address)).toBe(true);
                 expect(actual.gasPayer).toBeDefined();
-                expect(actual.gasPayer.isEqual(DelegatorFix.address)).toBe(
-                    true
-                );
+                expect(actual.gasPayer.isEqual(GasPayerFix.address)).toBe(true);
                 expect(actual.isDelegated).toBe(true);
                 expect(actual.id).toBeDefined();
                 expect(actual.isSigned).toBe(true);
@@ -685,7 +677,7 @@ describe('Transaction class tests', () => {
                 TransactionFixture.delegated.body
             ).signAsSenderAndGasPayer(
                 SignerFix.privateKey,
-                DelegatorFix.privateKey
+                GasPayerFix.privateKey
             );
             const signed = Transaction.of(
                 TransactionFixture.delegated.body
@@ -693,7 +685,7 @@ describe('Transaction class tests', () => {
             const signer = Address.ofPrivateKey(SignerFix.privateKey);
             const actual = signed.signAsGasPayer(
                 signer,
-                DelegatorFix.privateKey
+                GasPayerFix.privateKey
             );
             expect(actual.signature).toEqual(expected.signature);
         });
@@ -737,7 +729,7 @@ describe('Transaction class tests', () => {
                 TransactionFixture.delegated.body
             ).signAsSenderAndGasPayer(
                 SignerFix.privateKey,
-                DelegatorFix.privateKey
+                GasPayerFix.privateKey
             );
             const actual = Transaction.of(
                 TransactionFixture.delegated.body
@@ -775,7 +767,7 @@ describe('Transaction class tests', () => {
                 TransactionFixture.delegated.body
             ).signAsSenderAndGasPayer(
                 SignerFix.privateKey,
-                DelegatorFix.privateKey
+                GasPayerFix.privateKey
             );
             expect(actual.isDelegated).toBe(true);
             expect(actual.id).toBeDefined();
@@ -784,7 +776,7 @@ describe('Transaction class tests', () => {
                 Secp256k1.SIGNATURE_LENGTH * 2
             );
             expect(actual.origin.isEqual(SignerFix.address)).toBe(true);
-            expect(actual.gasPayer.isEqual(DelegatorFix.address)).toBe(true);
+            expect(actual.gasPayer.isEqual(GasPayerFix.address)).toBe(true);
         });
 
         test('Throw <- undelegated tx', () => {
@@ -793,7 +785,7 @@ describe('Transaction class tests', () => {
                     TransactionFixture.undelegated.body
                 ).signAsSenderAndGasPayer(
                     SignerFix.privateKey,
-                    DelegatorFix.privateKey
+                    GasPayerFix.privateKey
                 )
             ).toThrowError(NotDelegatedTransaction);
         });
@@ -804,7 +796,7 @@ describe('Transaction class tests', () => {
                     TransactionFixture.undelegated.body
                 ).signAsSenderAndGasPayer(
                     HexUInt.of('0xF00DBABE').bytes, // https://en.wikipedia.org/wiki/Hexspeak
-                    DelegatorFix.privateKey
+                    GasPayerFix.privateKey
                 )
             ).toThrowError(InvalidSecp256k1PrivateKey);
         });

--- a/packages/errors/src/available-errors/transaction/transaction.ts
+++ b/packages/errors/src/available-errors/transaction/transaction.ts
@@ -30,7 +30,7 @@ class InvalidTransactionField extends VechainSDKError<
  * * Error will be thrown when the transaction is not delegated.
  */
 class NotDelegatedTransaction extends VechainSDKError<
-    undefined | { delegatorUrl: string }
+    undefined | { gasPayerUrl: string }
 > {}
 
 /**

--- a/packages/errors/tests/available-errors/transaction.unit.test.ts
+++ b/packages/errors/tests/available-errors/transaction.unit.test.ts
@@ -66,7 +66,7 @@ describe('Error package Available errors test - Transaction', () => {
      */
     const testNotDelegatedTransaction = (
         innerError?: Error,
-        data?: { delegatorUrl: string }
+        data?: { gasPayerUrl: string }
     ): void => {
         expect(() => {
             throw new NotDelegatedTransaction(
@@ -84,8 +84,8 @@ describe('Error package Available errors test - Transaction', () => {
     test('NotDelegatedTransaction', () => {
         [undefined, new Error('error')].forEach((innerError) => {
             // Use a valid object or explicitly check for undefined
-            const dataOptions: Array<{ delegatorUrl: string } | undefined> = [
-                { delegatorUrl: 'url' },
+            const dataOptions: Array<{ gasPayerUrl: string } | undefined> = [
+                { gasPayerUrl: 'url' },
                 undefined
             ];
 

--- a/packages/network/src/signer/signers/vechain-abstract-signer/vechain-abstract-signer.ts
+++ b/packages/network/src/signer/signers/vechain-abstract-signer/vechain-abstract-signer.ts
@@ -51,7 +51,7 @@ abstract class VeChainAbstractSigner implements VeChainSigner {
      * @param provider - The provider to connect to
      */
     protected constructor(provider?: AvailableVeChainProviders) {
-        // Store provider and delegator
+        // Store provider and gasPayer
         this.provider = provider;
     }
 

--- a/packages/network/src/thor-client/transactions/helpers/delegation-handler.ts
+++ b/packages/network/src/thor-client/transactions/helpers/delegation-handler.ts
@@ -48,7 +48,7 @@ const _getDelegationSignature = async (
             '_getDelegationSignature()',
             'Delegation failed: Cannot get signature from delegator.',
             {
-                delegatorUrl
+                gasPayerUrl: delegatorUrl
             },
             error
         );


### PR DESCRIPTION
# Description

This PR removes the expression `delegator` to mean the gas-payer of delegated transactions in

- `packages/core/src/transaction`
- `packages/network/src/signer/signers`

The misleading `delegator` expression is still present in other places of the the SDK, the refactoring to correct terminology is the goal of following PRs. 

Fixes # BNC

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `yarn test:examples`
- [x] `yarn test:solo`
- [x] `yarn test:unit` 

**Test Configuration**:
* Node.js Version: v23.1.0
* Yarn Version: 1.22.22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated terminology from "delegator" to "gas-payer" across documentation and code examples.
	- Clarified fee delegation terminology in transaction and contract documentation.
	- Added comments indicating upcoming deprecation of "delegator" term.

- **Refactor**
	- Renamed variables and method names to consistently use "gas-payer" terminology.
	- Updated error handling to reflect new terminology.

- **Tests**
	- Updated test cases to use new "gas-payer" naming conventions.
	- Maintained existing test logic and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->