### PR TITLE
1842 new net p1   change timestamps from using bigint to using uint

### DIFF
--- a/docs/diagrams/v2/net/thor/blocks/blocks.md
+++ b/docs/diagrams/v2/net/thor/blocks/blocks.md
@@ -27,7 +27,7 @@ classDiagram
         id: ThorId
         size: UInt
         parentID: ThorId
-        timestamp: bigint
+        timestamp: UInt
         gasLimit: VTHO
         beneficiary: Address
         gasUsed: VTHO
@@ -50,7 +50,7 @@ classDiagram
         id: string
         size: number
         parentID: string
-        timestamp: bigint
+        timestamp: number
         gasLimit: number
         beneficiary: string
         gasUsed: number

--- a/docs/diagrams/v2/net/thor/transactions/transactions.md
+++ b/docs/diagrams/v2/net/thor/transactions/transactions.md
@@ -106,14 +106,14 @@ classDiagram
     class TxMeta {
         blockID: BlockId
         blockNumber: UInt
-        blockTimestamp: bigint
+        blockTimestamp: UInt
         constructor(json: TxMetaJSON) TxMeta
         toJSON() TxMetaJSON
     }
     class TxMetaJSON {
         blockID: string
         blockNumber: number
-        blockTimestamp: bigint
+        blockTimestamp: number
     }
     class Receipt {
         gasUsed: VTHO
@@ -218,14 +218,14 @@ classDiagram
     class TxMeta {
         blockID: BlockId
         blockNumber: UInt
-        blockTimestamp: bigint
+        blockTimestamp: UInt
         constructor(json: TxMetaJSON) TxMeta
         toJSON() TxMetaJSON
     }
     class TxMetaJSON {
         blockID: string
         blockNumber: number
-        blockTimestamp: bigint
+        blockTimestamp: number
     }
     Clause --> "new - toJSON" ClauseJSON
     Event --> "new - toJSON" EventJSON

--- a/packages/thorest/src/thor/blocks/ExpandedBlockResponse.ts
+++ b/packages/thorest/src/thor/blocks/ExpandedBlockResponse.ts
@@ -20,7 +20,7 @@ class TransactionWithOutputs {
             meta: {
                 blockID: BlockId.of(0).fit(64).toString(),
                 blockNumber: 0,
-                blockTimestamp: 0n
+                blockTimestamp: 0
             }
         });
 

--- a/packages/thorest/src/thor/transactions/TxMeta.ts
+++ b/packages/thorest/src/thor/transactions/TxMeta.ts
@@ -3,19 +3,19 @@ import { BlockId, UInt } from '@vechain/sdk-core';
 class TxMeta {
     readonly blockID: BlockId;
     readonly blockNumber: UInt;
-    readonly blockTimestamp: bigint;
+    readonly blockTimestamp: UInt;
 
     constructor(json: TxMetaJSON) {
         this.blockID = BlockId.of(json.blockID);
         this.blockNumber = UInt.of(json.blockNumber);
-        this.blockTimestamp = json.blockTimestamp;
+        this.blockTimestamp = UInt.of(json.blockTimestamp);
     }
 
     toJSON(): TxMetaJSON {
         return {
             blockID: this.blockID.toString(),
             blockNumber: this.blockNumber.valueOf(),
-            blockTimestamp: this.blockTimestamp
+            blockTimestamp: this.blockTimestamp.valueOf()
         } satisfies TxMetaJSON;
     }
 }
@@ -23,7 +23,7 @@ class TxMeta {
 interface TxMetaJSON {
     blockID: string;
     blockNumber: number;
-    blockTimestamp: bigint;
+    blockTimestamp: number;
 }
 
 export { TxMeta, type TxMetaJSON };


### PR DESCRIPTION
# Description

Changing from using `bigint` to using VCDM's `UInt` for timestamps

Fixes #1842

## Type of change

Chore and doc update

# How Has This Been Tested?

Unit/integration tests passing

**Test Configuration**:
* Node.js Version:
* Yarn Version:

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code