### PR TITLE
fix: 1874 `Transaction.getTransactionHash(sender)` rename

### DIFF
--- a/docs/diagrams/architecture/transaction.md
+++ b/docs/diagrams/architecture/transaction.md
@@ -34,7 +34,7 @@ classDiagram
         +Address origin
         +Uint8Array signature?
         +Transaction decode(Uint8Array rawTransaction, boolean isSigned)$
-        +Blake2b256 getTransactionHash(Address gasPayer?)
+        +Blake2b256 getTransactionHash(Address sender?)
         +VTHO intrinsicGas(TransactionClause[] clauses)$
         +boolean isValidBody(TransactionBody body)$
         +Transaction of(TransactionBody: body, Uint8Array signature?)$

--- a/packages/core/src/transaction/Transaction.ts
+++ b/packages/core/src/transaction/Transaction.ts
@@ -380,20 +380,20 @@ class Transaction {
     /**
      * Computes the transaction hash, optionally incorporating a gas payer's address.
      *
-     * @param {Address} [gasPayer] - Optional gas payer's address to include in the hash computation.
+     * @param {Address} [sender] - Optional transaction origin's address to include in the hash computation.
      * @return {Blake2b256} - The computed transaction hash.
      *
      * @remarks
-     * `gasPayer` is used to sign a transaction on behalf of another account.
+     * `sender` is used to sign a transaction on behalf of another account.
      *
      * @remarks Security auditable method, depends on
      * - {@link Blake2b256.of}.
      */
-    public getTransactionHash(gasPayer?: Address): Blake2b256 {
+    public getTransactionHash(sender?: Address): Blake2b256 {
         const txHash = Blake2b256.of(this.encode(false));
-        if (gasPayer !== undefined) {
+        if (sender !== undefined) {
             return Blake2b256.of(
-                nc_utils.concatBytes(txHash.bytes, gasPayer.bytes)
+                nc_utils.concatBytes(txHash.bytes, sender.bytes)
             );
         }
         return txHash;


### PR DESCRIPTION
# Description

Class packages/core/src/transaction/Transaction.ts renamed as getTransactionHash(sender?: Address): Blake2b256 the argument previously named gasPayer.

Fixes #1874

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `yarn test:solo`
- [x] `yarn test:unit`

**Test Configuration**:
* Node.js Version: v23.1.0
* Yarn Version: 1.22.22


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed the transaction signing parameter to more accurately describe its role, ensuring clarity for users.
- **Documentation**
	- Updated documentation to reflect the new naming convention while maintaining the existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->