### PR TITLE
Allowing signasgaspayer on unsigned tx

### DIFF
--- a/packages/core/src/transaction/Transaction.ts
+++ b/packages/core/src/transaction/Transaction.ts
@@ -557,8 +557,8 @@ class Transaction {
     ): Transaction {
         if (Secp256k1.isValidPrivateKey(gasPayerPrivateKey)) {
             if (this.isDelegated) {
+                const senderHash = this.getTransactionHash(sender).bytes;
                 if (this.signature !== undefined) {
-                    const senderHash = this.getTransactionHash(sender).bytes;
                     return new Transaction(
                         this.body,
                         nc_utils.concatBytes(
@@ -567,12 +567,12 @@ class Transaction {
                             Secp256k1.sign(senderHash, gasPayerPrivateKey)
                         )
                     );
+                } else {
+                    return new Transaction(
+                        this.body,
+                        Secp256k1.sign(senderHash, gasPayerPrivateKey)
+                    );
                 }
-                throw new InvalidTransactionField(
-                    'Transaction.signAsGasPayer',
-                    'unsigned transaction: use signAsSender method',
-                    { fieldName: 'signature' }
-                );
             }
             throw new NotDelegatedTransaction(
                 'Transaction.signAsGasPayer',

--- a/packages/core/tests/transaction/Transaction.unit.test.ts
+++ b/packages/core/tests/transaction/Transaction.unit.test.ts
@@ -701,15 +701,17 @@ describe('Transaction class tests', () => {
             }).toThrowError(NotDelegatedTransaction);
         });
 
-        test('Throw <- unsigned tx', () => {
-            expect(() => {
-                Transaction.of(
-                    TransactionFixture.delegated.body
-                ).signAsGasPayer(
-                    Address.ofPrivateKey(SignerFix.privateKey),
-                    SignerFix.privateKey
-                );
-            }).toThrowError(InvalidTransactionField);
+        test('signature (only of the gasPayer) <- unsigned tx', () => {
+            expect(
+                (
+                    Transaction.of(
+                        TransactionFixture.delegated.body
+                    ).signAsGasPayer(
+                        Address.ofPrivateKey(SignerFix.privateKey),
+                        SignerFix.privateKey
+                    ).signature as Uint8Array
+                ).length
+            ).toBe(65);
         });
 
         test('Throw <- invalid private keys - delegated tx', () => {


### PR DESCRIPTION
# Description

Allowing the use of signAsGasPayer with an unsigned transaction. In order to maintain backwards compatibility, for people using it with transactions that are signed by the sender, it returns the transaction with just the signature of the gas payer. Therefore, the resulting transaction object cannot be broadcasted right after, it needs to be manually rebuilt to contain both the sender and the gaspayer signature concatenated.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Fixed unit tests

**Test Configuration**:
* Node.js Version:
* Yarn Version:

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code