### PR TITLE
fix: chainid

### DIFF
--- a/docker-compose.rpc-proxy.yml
+++ b/docker-compose.rpc-proxy.yml
@@ -39,7 +39,7 @@ services:
   # The Thor solo service
   thor-solo:
     container_name: thor-solo
-    image: ${THOR_IMAGE:-ghcr.io/vechain/thor:master-latest}
+    image: ${THOR_IMAGE:-ghcr.io/vechain/thor:latest}
     ports:
       - "8669:8669"
     command:

--- a/packages/network/src/provider/utils/const/chain-id/chain-id.ts
+++ b/packages/network/src/provider/utils/const/chain-id/chain-id.ts
@@ -1,4 +1,4 @@
-import { Hex, HexUInt } from '@vechain/sdk-core';
+import { HexUInt } from '@vechain/sdk-core';
 
 /**
  * Chain ID's this is the blockId of the genesis block

--- a/packages/network/src/provider/utils/const/chain-id/chain-id.ts
+++ b/packages/network/src/provider/utils/const/chain-id/chain-id.ts
@@ -1,11 +1,35 @@
+import { Hex, HexUInt } from '@vechain/sdk-core';
+
 /**
  * Chain ID's this is the blockId of the genesis block
  */
 const CHAIN_ID = {
-    MAINNET:
-        '0x00000000851caf3cfdb6e899cf5958bfb1ac3413d346d43539627e6be7ec1b4a',
-    TESTNET:
-        '0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127'
+    MAINNET: '0x186a9',
+    TESTNET: '0x186aa',
+    SOLO_DEFAULT: '0xf6'
 };
 
-export { CHAIN_ID };
+const CHAIN_TAG = {
+    MAINNET: '0x4a',
+    TESTNET: '0x27',
+    SOLO_DEFAULT: '0xf6'
+};
+
+/**
+ * Converts a chain tag to a chain Id
+ * @param chainTag chain tag as last byte of genesis block id
+ * @returns chain id
+ */
+const chainTagToChainId = (chainTag: HexUInt): HexUInt => {
+    if (chainTag.isEqual(HexUInt.of(CHAIN_TAG.MAINNET))) {
+        return HexUInt.of(CHAIN_ID.MAINNET);
+    } else if (chainTag.isEqual(HexUInt.of(CHAIN_TAG.TESTNET))) {
+        return HexUInt.of(CHAIN_ID.TESTNET);
+    } else if (chainTag.isEqual(HexUInt.of(CHAIN_TAG.SOLO_DEFAULT))) {
+        return HexUInt.of(CHAIN_ID.SOLO_DEFAULT);
+    } else {
+        return chainTag;
+    }
+};
+
+export { CHAIN_ID, CHAIN_TAG, chainTagToChainId };

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_chainId/eth_chainId.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_chainId/eth_chainId.ts
@@ -1,14 +1,16 @@
-import { Hex } from '@vechain/sdk-core';
+import { Hex, HexUInt } from '@vechain/sdk-core';
 import { type ThorClient } from '../../../../../thor-client';
 import {
     JSONRPCInternalError,
     JSONRPCInvalidParams,
     stringifyData
 } from '@vechain/sdk-errors';
+import { chainTagToChainId } from '../../../const';
 
 // In-memory cache
-let cachedChainId: Hex | null = null;
-let cachedChainTag: Hex | null = null;
+let cachedChainId: HexUInt | null = null;
+let cachedChainTag: HexUInt | null = null;
+let cachedGenesisBlockId: Hex | null = null;
 
 /**
  * RPC Method eth_chainId implementation
@@ -41,9 +43,9 @@ const ethChainId = async (thorClient: ThorClient): Promise<string> => {
                 }
             );
         }
-        const genesisBlockId = Hex.of(genesisBlock.id);
-        cachedChainId = genesisBlockId;
-        cachedChainTag = Hex.of(genesisBlockId.bytes.slice(-2));
+        cachedGenesisBlockId = Hex.of(genesisBlock.id);
+        cachedChainTag = HexUInt.of(cachedGenesisBlockId.bytes.slice(-1));
+        cachedChainId = chainTagToChainId(cachedChainTag);
         return cachedChainId.toString();
     } catch (e) {
         throw new JSONRPCInternalError(

--- a/packages/network/tests/provider/fixture.ts
+++ b/packages/network/tests/provider/fixture.ts
@@ -23,8 +23,7 @@ const blockWithTransactionsExpanded = {
             blockNumber: '0x10b7a6d',
             from: '0x7487d912d03ab9de786278f679592b3730bdd540',
             gas: '0x7436',
-            chainId:
-                '0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127',
+            chainId: '0x186aa',
             hash: '0xd331443a31ef1f32e2c4510710e62561012de11ef404c35086629436e4d5dded',
             nonce: '0xb8314776ce0bf5df',
             transactionIndex: '0x0',
@@ -47,8 +46,7 @@ const blockWithTransactionsExpanded = {
             blockNumber: '0x10b7a6d',
             from: '0x7487d912d03ab9de786278f679592b3730bdd540',
             gas: '0xbd30',
-            chainId:
-                '0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127',
+            chainId: '0x186aa',
             hash: '0x6994801b6f92f9a0a151ab4ac1c27d2dcf2ab61245b10ddf05504ae5384e759d',
             nonce: '0x176bbcbf79a3a672',
             transactionIndex: '0x1',
@@ -71,8 +69,7 @@ const blockWithTransactionsExpanded = {
             blockNumber: '0x10b7a6d',
             from: '0x7487d912d03ab9de786278f679592b3730bdd540',
             gas: '0xd14a',
-            chainId:
-                '0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127',
+            chainId: '0x186aa',
             hash: '0xb476d1a43b8632c25a581465c944a1cb5dd99e48d41d326a250847a0a279afa5',
             nonce: '0x7022eb9454a648b9',
             transactionIndex: '0x2',
@@ -158,8 +155,7 @@ const validTransactionDetailTestnet = {
     blockNumber: '0x10b7b5f',
     from: '0x8c59c63d6458c71b6ff88d57698437524a703084',
     gas: '0x618af',
-    chainId:
-        '0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127',
+    chainId: '0x186aa',
     hash: '0xb2e3f6e9782f462d797b72f9cbf5a4c38ca20cabcc1a091f9de6d3e6736c1f7c',
     nonce: '0x19b4782',
     transactionIndex: '0x0',

--- a/packages/network/tests/provider/providers/fixture.ts
+++ b/packages/network/tests/provider/providers/fixture.ts
@@ -25,8 +25,7 @@ const providerMethodsTestCasesTestnet = [
         description: 'Should be able to call eth_chainId',
         method: 'eth_chainId',
         params: [],
-        expected:
-            '0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127'
+        expected: '0x186aa'
     },
     {
         description: `Should be able to call eth_getTransactionByHash with ${validTransactionHashTestnet} as the transaction hash`,

--- a/packages/network/tests/provider/rpc-mapper/methods/eth_chainId/eth_chainId.solo.test.ts
+++ b/packages/network/tests/provider/rpc-mapper/methods/eth_chainId/eth_chainId.solo.test.ts
@@ -6,8 +6,7 @@ import {
     ThorClient
 } from '../../../../../src';
 
-const soloChainId =
-    '0x00000000c05a20fbca2bf6ae3affba6af4a74b800b585bf7a4988aba7aea69f6';
+const soloChainId = '0xf6';
 
 /**
  * RPC Mapper integration tests for 'eth_chainId' method

--- a/packages/network/tests/provider/rpc-mapper/methods/eth_getTransactionByBlockHashAndIndex/fixture.ts
+++ b/packages/network/tests/provider/rpc-mapper/methods/eth_getTransactionByBlockHashAndIndex/fixture.ts
@@ -19,8 +19,7 @@ const ethGetTransactionByBlockHashAndIndexTestCases = [
             blockNumber: '0x10b7a6d',
             from: '0x7487d912d03ab9de786278f679592b3730bdd540',
             gas: '0xbd30',
-            chainId:
-                '0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127',
+            chainId: '0x186aa',
             hash: '0x6994801b6f92f9a0a151ab4ac1c27d2dcf2ab61245b10ddf05504ae5384e759d',
             nonce: '0x176bbcbf79a3a672',
             transactionIndex: '0x1',
@@ -50,8 +49,7 @@ const ethGetTransactionByBlockHashAndIndexTestCases = [
             blockHash:
                 '0x010b7a6d6f04407ac2f72e505ff83d49db8d01607f8af41f508b2ca7eca0d450',
             blockNumber: '0x10b7a6d',
-            chainId:
-                '0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127',
+            chainId: '0x186aa',
             from: '0x7487d912d03ab9de786278f679592b3730bdd540',
             gas: '0x7436',
             gasPrice: '0x0',

--- a/packages/network/tests/provider/rpc-mapper/methods/eth_getTransactionByBlockNumberAndIndex/fixture.ts
+++ b/packages/network/tests/provider/rpc-mapper/methods/eth_getTransactionByBlockNumberAndIndex/fixture.ts
@@ -17,8 +17,7 @@ const ethGetTransactionByBlockNumberAndIndexTestCases = [
             blockNumber: '0x10b7a6d',
             from: '0x7487d912d03ab9de786278f679592b3730bdd540',
             gas: '0xbd30',
-            chainId:
-                '0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127',
+            chainId: '0x186aa',
             hash: '0x6994801b6f92f9a0a151ab4ac1c27d2dcf2ab61245b10ddf05504ae5384e759d',
             nonce: '0x176bbcbf79a3a672',
             transactionIndex: '0x1',
@@ -45,8 +44,7 @@ const ethGetTransactionByBlockNumberAndIndexTestCases = [
             blockHash:
                 '0x010b7a6d6f04407ac2f72e505ff83d49db8d01607f8af41f508b2ca7eca0d450',
             blockNumber: '0x10b7a6d',
-            chainId:
-                '0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127',
+            chainId: '0x186aa',
             from: '0x7487d912d03ab9de786278f679592b3730bdd540',
             gas: '0x7436',
             gasPrice: '0x0',

--- a/packages/rpc-proxy/README.md
+++ b/packages/rpc-proxy/README.md
@@ -274,7 +274,13 @@ The following mappings are performed by the RPC proxy
 | finalized block                        | finalized block       |
 | pending block                          | best block            |
 | earliest block                         | block number 0        |
-| chainId                                | genesis block id      |
+
+
+The method `eth_chainId` returns:
+
+* `0x186a9` for mainnet
+* `0x186aa` for testnet
+* for solo or other custom networks it returns the _chainTag_ (the last byte of the genesis block id)
 
 
 ## Transaction Coversions

--- a/packages/rpc-proxy/tests/e2e_rpc_proxy.solo.test.ts
+++ b/packages/rpc-proxy/tests/e2e_rpc_proxy.solo.test.ts
@@ -9,8 +9,7 @@ import {
 
 let environment: StartedDockerComposeEnvironment;
 const RPC_PROXY_URL = `http://localhost:8545`;
-const genesisBlockId =
-    '0x0000000008602e7a995c747a3215b426c0c65709480b9e9ac57ad37c3f7d73de'; // custom genesis block id as solo is using a custom genesis file
+const genesisChainId = '0xde'; // custom genesis block id as solo is using a custom genesis file
 
 beforeAll(async () => {
     environment = await new DockerComposeEnvironment(
@@ -204,7 +203,7 @@ describe('RPC Proxy endpoints', () => {
             console.log(response.data);
             expect(response.data).toHaveProperty('result');
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            expect(response.data.result).toBe(genesisBlockId);
+            expect(response.data.result).toBe(genesisChainId);
         });
 
         it('eth_estimateGas method call', async () => {
@@ -767,7 +766,7 @@ describe('RPC Proxy endpoints', () => {
             console.log(response.data);
             expect(response.data).toHaveProperty('result');
             expect((response.data as { result: string }).result).toBe(
-                genesisBlockId
+                genesisChainId
             );
         });
 

--- a/scripts/test-rpc-proxy.ts
+++ b/scripts/test-rpc-proxy.ts
@@ -4,14 +4,12 @@ const endpointsTestCases = [
     {
         method: 'net_version',
         params: [],
-        expected:
-            '0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127'
+        expected: '0x186aa'
     },
     {
         method: 'eth_chainId',
         params: [],
-        expected:
-            '0x000000000b2bce3c70bc649a02749e8687721b09ed2e15997f466536b20bb127'
+        expected: '0x186aa'
     },
     {
         method: 'web3_clientVersion',


### PR DESCRIPTION
# Description

Fixes the chain Id to return `0x186a9` for mainnet and `0x186aa` for testnet
For other networks (solo or some custom genesis) it returns the chain tag (last byte of the genesis block id)

Fixes: Integration issue feedback

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] RPC unit tests
- [x] RPC docker tests

**Test Configuration**:
* Node.js Version: 18.18.0

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code