### PR TITLE
Fix - 1757

### DIFF
--- a/packages/core/src/transaction/Clause.ts
+++ b/packages/core/src/transaction/Clause.ts
@@ -136,7 +136,10 @@ class Clause implements TransactionClause {
         amount: VET = VET.of(FixedPointNumber.ZERO),
         clauseOptions?: ClauseOptions
     ): Clause {
-        if (amount.value.isFinite() && amount.value.isPositive()) {
+        if (
+            amount.value.isFinite() &&
+            amount.value.gte(FixedPointNumber.ZERO)
+        ) {
             return new Clause(
                 contractAddress.toString().toLowerCase(),
                 Hex.PREFIX + amount.wei.toString(Hex.RADIX),

--- a/packages/core/tests/transaction/Clause.unit.test.ts
+++ b/packages/core/tests/transaction/Clause.unit.test.ts
@@ -89,6 +89,22 @@ describe('Clause class tests', () => {
             expect(actual.data).toBeDefined();
         });
 
+        test('Return Clause <- VET value is zero', () => {
+            const actual = Clause.callFunction(
+                ClauseFixture.contract.address,
+                ABIContract.ofAbi(ClauseFixture.contract.abi).getFunction(
+                    'set'
+                ),
+                [1],
+                VET.of(0)
+            );
+            expect(actual.to).toBe(
+                ClauseFixture.contract.address.toString().toLowerCase()
+            );
+            expect(actual.amount().isZero()).toBe(true);
+            expect(actual.data).toBeDefined();
+        });
+
         test('Return Clause <- call function & comment', () => {
             const comment = 'Setting x = 1.';
             const actual = Clause.callFunction(


### PR DESCRIPTION
# Description

The CallFunction clause builder would only accept a VET value > 0. This fixes an edge case where the clause can contain a zero value field.

Fixes #1757 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Package unit tests

**Test Configuration**:
* Node.js Version: 18.18.0

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code