### PR TITLE
2075 bug   fix fixed point precision math tests

### DIFF
--- a/packages/core/src/vcdm/FixedPointNumber.ts
+++ b/packages/core/src/vcdm/FixedPointNumber.ts
@@ -252,25 +252,22 @@ class FixedPointNumber implements VeChainDataModel<FixedPointNumber> {
      */
     public div(that: FixedPointNumber): FixedPointNumber {
         if (this.isNaN() || that.isNaN()) return FixedPointNumber.NaN;
-        if (this.isNegativeInfinite())
-            return that.isInfinite()
-                ? FixedPointNumber.NaN
-                : that.isPositive()
-                  ? FixedPointNumber.NEGATIVE_INFINITY
-                  : FixedPointNumber.POSITIVE_INFINITY;
-        if (this.isPositiveInfinite())
-            return that.isInfinite()
-                ? FixedPointNumber.NaN
-                : that.isPositive()
-                  ? FixedPointNumber.POSITIVE_INFINITY
-                  : FixedPointNumber.NEGATIVE_INFINITY;
+        if (this.isNegativeInfinite()) {
+            if (that.isInfinite()) return FixedPointNumber.NaN;
+            if (that.isPositive()) return FixedPointNumber.NEGATIVE_INFINITY;
+            return FixedPointNumber.POSITIVE_INFINITY;
+        }
+        if (this.isPositiveInfinite()) {
+            if (that.isInfinite()) return FixedPointNumber.NaN;
+            if (that.isPositive()) return FixedPointNumber.POSITIVE_INFINITY;
+            return FixedPointNumber.NEGATIVE_INFINITY;
+        }
         if (that.isInfinite()) return FixedPointNumber.ZERO;
-        if (that.isZero())
-            return this.isZero()
-                ? FixedPointNumber.NaN
-                : this.isNegative()
-                  ? FixedPointNumber.NEGATIVE_INFINITY
-                  : FixedPointNumber.POSITIVE_INFINITY;
+        if (that.isZero()) {
+            if (this.isZero()) return FixedPointNumber.NaN;
+            if (this.isNegative()) return FixedPointNumber.NEGATIVE_INFINITY;
+            return FixedPointNumber.POSITIVE_INFINITY;
+        }
         const fd = this.maxFractionalDigits(that, this.fractionalDigits); // Max common fractional decimals.
         return new FixedPointNumber(
             fd,
@@ -397,25 +394,22 @@ class FixedPointNumber implements VeChainDataModel<FixedPointNumber> {
      */
     public idiv(that: FixedPointNumber): FixedPointNumber {
         if (this.isNaN() || that.isNaN()) return FixedPointNumber.NaN;
-        if (this.isNegativeInfinite())
-            return that.isInfinite()
-                ? FixedPointNumber.NaN
-                : that.isPositive()
-                  ? FixedPointNumber.NEGATIVE_INFINITY
-                  : FixedPointNumber.POSITIVE_INFINITY;
-        if (this.isPositiveInfinite())
-            return that.isInfinite()
-                ? FixedPointNumber.NaN
-                : that.isPositive()
-                  ? FixedPointNumber.POSITIVE_INFINITY
-                  : FixedPointNumber.NEGATIVE_INFINITY;
+        if (this.isNegativeInfinite()) {
+            if (that.isInfinite()) return FixedPointNumber.NaN;
+            if (that.isPositive()) return FixedPointNumber.NEGATIVE_INFINITY;
+            return FixedPointNumber.POSITIVE_INFINITY;
+        }
+        if (this.isPositiveInfinite()) {
+            if (that.isInfinite()) return FixedPointNumber.NaN;
+            if (that.isPositive()) return FixedPointNumber.POSITIVE_INFINITY;
+            return FixedPointNumber.NEGATIVE_INFINITY;
+        }
         if (that.isInfinite()) return FixedPointNumber.ZERO;
-        if (that.isZero())
-            return this.isZero()
-                ? FixedPointNumber.NaN
-                : this.isNegative()
-                  ? FixedPointNumber.NEGATIVE_INFINITY
-                  : FixedPointNumber.POSITIVE_INFINITY;
+        if (that.isZero()) {
+            if (this.isZero()) return FixedPointNumber.NaN;
+            if (this.isNegative()) return FixedPointNumber.NEGATIVE_INFINITY;
+            return FixedPointNumber.POSITIVE_INFINITY;
+        }
         const fd = this.maxFractionalDigits(that, this.fractionalDigits); // Max common fractional decimals.
         return new FixedPointNumber(
             fd,
@@ -648,13 +642,13 @@ class FixedPointNumber implements VeChainDataModel<FixedPointNumber> {
      * If the maximum fixed digits value is less than `minFixedDigits`, return `minFixedDigits`.
      *
      * @param {FixedPointNumber} that to evaluate if `that` has the maximum fixed digits value.
-     * @param {bigint} minFixedDigits Min value of returned value, {@link FixedPointNumber.DEFAULT_FRACTIONAL_DECIMALS} by default.
+     * @param {bigint} minFixedDigits Min value of returned value.
      *
      * @return the greater fixed digits value among `this`, `that` and `minFixedDigits`.
      */
     private maxFractionalDigits(
         that: FixedPointNumber,
-        minFixedDigits: bigint = FixedPointNumber.DEFAULT_FRACTIONAL_DECIMALS
+        minFixedDigits: bigint
     ): bigint {
         const fd =
             this.fractionalDigits < that.fractionalDigits

--- a/packages/core/tests/vcdm/FixedPointNumber.unit.test.ts
+++ b/packages/core/tests/vcdm/FixedPointNumber.unit.test.ts
@@ -600,6 +600,12 @@ describe('FixedPointNumber class tests', () => {
             const actual = FixedPointNumber.of(n).dp(fd);
             expect(actual.isEqual(expected)).toBe(true);
         });
+
+        test(' scale negative -> err', () => {
+            expect(() => {
+                FixedPointNumber.of(123.45).dp(-1n);
+            }).toThrow(InvalidDataType);
+        });
     });
 
     describe('div method tests', () => {
@@ -643,8 +649,8 @@ describe('FixedPointNumber class tests', () => {
         test('-Infinite / +n -> -Infinite', () => {
             expect(
                 FixedPointNumber.NEGATIVE_INFINITY.div(
-                    FixedPointNumber.of(-123.45)
-                ).isPositive()
+                    FixedPointNumber.of(123.45)
+                ).isNegativeInfinite()
             ).toBe(true);
         });
 
@@ -796,8 +802,8 @@ describe('FixedPointNumber class tests', () => {
         test('-Infinite / +n -> -Infinite', () => {
             expect(
                 FixedPointNumber.NEGATIVE_INFINITY.idiv(
-                    FixedPointNumber.of(-123.45)
-                ).isPositiveInfinite()
+                    FixedPointNumber.of(123.45)
+                ).isNegativeInfinite()
             ).toBe(true);
         });
 
@@ -2615,27 +2621,32 @@ describe('FixedPointNumber class tests', () => {
         test('< 1', () => {
             const expected = 0.0001;
             const actual = FixedPointNumber.of(expected);
-            expect(actual.n).toBeCloseTo(expected);
+            expect(actual.toString()).toEqual(expected.toString());
         });
         test('> 1', () => {
             const expected = 123.456;
             const actual = FixedPointNumber.of(123.456);
-            expect(actual.n).toBeCloseTo(expected);
+            expect(actual.toString()).toEqual(expected.toString());
         });
         test('NaN', () => {
             const expected = Number.NaN;
             const actual = FixedPointNumber.of(expected);
-            expect(actual.n).toBe(expected);
+            expect(actual.toString()).toEqual(expected.toString());
         });
         test('-Infinity', () => {
             const expected = -Infinity;
             const actual = FixedPointNumber.of(-Infinity);
-            expect(actual.n).toBeCloseTo(expected);
+            expect(actual.toString()).toEqual(expected.toString());
         });
         test('+Infinity', () => {
             const expected = -Infinity;
             const actual = FixedPointNumber.of(expected);
-            expect(actual.n).toBeCloseTo(expected);
+            expect(actual.toString()).toEqual(expected.toString());
+        });
+        test('no fractional digits', () => {
+            const expected = 123;
+            const actual = FixedPointNumber.of(expected, 0n);
+            expect(actual.toString()).toEqual(expected.toString());
         });
     });
 });

--- a/packages/core/tests/vcdm/FixedPointNumber.unit.test.ts
+++ b/packages/core/tests/vcdm/FixedPointNumber.unit.test.ts
@@ -64,8 +64,8 @@ describe('FixedPointNumber class tests', () => {
 
             test('±n', () => {
                 const n = 123.45;
-                expect(FixedPointNumber.of(n).n).toEqual(n);
-                expect(FixedPointNumber.of(-n).n).toEqual(-n);
+                expect(FixedPointNumber.of(n).n).toBeCloseTo(n);
+                expect(FixedPointNumber.of(-n).n).toBeCloseTo(-n);
             });
         });
 
@@ -337,35 +337,35 @@ describe('FixedPointNumber class tests', () => {
             const n = NaN;
             const actual = FixedPointNumber.of(n);
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.toString()).toBe(n.toString());
+            expect(actual.n).toBe(n);
         });
 
         test('of -Infinity', () => {
             const n = -Infinity;
             const actual = FixedPointNumber.of(n);
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.toString()).toBe(n.toString());
+            expect(actual.n).toBe(n);
         });
 
         test('of +Infinity', () => {
             const n = Infinity;
             const actual = FixedPointNumber.of(n);
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.toString()).toBe(n.toString());
+            expect(actual.n).toBe(n);
         });
 
         test('of -bigint', () => {
             const bi = -12345678901234567890n;
             const actual = FixedPointNumber.of(bi);
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.toString()).toBe(bi.toString());
+            expect(actual.bi).toBe(bi);
         });
 
         test('of +bigint', () => {
             const bi = 12345678901234567890n;
             const actual = FixedPointNumber.of(bi);
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.toString()).toBe(bi.toString());
+            expect(actual.bi).toBe(bi);
         });
 
         test('of FixedPointNumber', () => {
@@ -378,28 +378,28 @@ describe('FixedPointNumber class tests', () => {
             const n = 123.0067;
             const actual = FixedPointNumber.of(n);
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.toString()).toBe(n.toString());
+            expect(actual.n).toBeCloseTo(n);
         });
 
         test('of -n', () => {
             const n = -123.0067;
             const actual = FixedPointNumber.of(n);
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.toString()).toBe(n.toString());
+            expect(actual.n).toBeCloseTo(n);
         });
 
         test('of negative string', () => {
             const n = '-123.0067';
             const actual = FixedPointNumber.of(n.toString());
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.toString()).toBe(n.toString());
+            expect(actual.n).toBeCloseTo(Number(n));
         });
 
         test('of positive string', () => {
             const exp = '+123.45';
             const actual = FixedPointNumber.of(exp);
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.n).toBe(Number(exp));
+            expect(actual.n).toBeCloseTo(Number(exp));
         });
 
         test('of an illegal expression throws exception', () => {
@@ -429,14 +429,14 @@ describe('FixedPointNumber class tests', () => {
             const n = -0.8;
             const actual = FixedPointNumber.of(n).abs();
             const expected = BigNumber(n).abs();
-            expect(actual.n).toEqual(expected.toNumber());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('n > 0', () => {
             const n = 0.8;
             const actual = FixedPointNumber.of(n).abs();
             const expected = BigNumber(n).abs();
-            expect(actual.n).toEqual(expected.toNumber());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
     });
 
@@ -608,7 +608,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 0;
             const actual = FixedPointNumber.of(lr).div(FixedPointNumber.of(r));
             const expected = BigNumber(lr).div(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
         test('NaN / n = ', () => {
@@ -616,7 +616,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 123.45;
             const actual = FixedPointNumber.of(lr).div(FixedPointNumber.of(r));
             const expected = BigNumber(lr).div(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
         test('-Infinite / ±Infinite -> NaN', () => {
@@ -682,7 +682,7 @@ describe('FixedPointNumber class tests', () => {
             const y = FixedPointNumber.of(NaN);
             const actual = x.div(y);
             const expected = BigNumber(x.n).div(BigNumber(y.n));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
         test('n / -Infinity = 0', () => {
@@ -690,7 +690,7 @@ describe('FixedPointNumber class tests', () => {
             const r = -Infinity;
             const actual = FixedPointNumber.of(lr).div(FixedPointNumber.of(r));
             const expected = BigNumber(lr).div(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('n / +Infinity = 0', () => {
@@ -698,7 +698,7 @@ describe('FixedPointNumber class tests', () => {
             const r = Infinity;
             const actual = FixedPointNumber.of(lr).div(FixedPointNumber.of(r));
             const expected = BigNumber(lr).div(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
         test('-n / 0 = -Infinity', () => {
@@ -706,7 +706,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 0;
             const actual = FixedPointNumber.of(lr).div(FixedPointNumber.of(r));
             const expected = BigNumber(lr).div(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
         test('+n / 0 = +Infinity', () => {
@@ -714,7 +714,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 0;
             const actual = FixedPointNumber.of(lr).div(FixedPointNumber.of(r));
             const expected = BigNumber(lr).div(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
         test('x / y = periodic', () => {
@@ -722,10 +722,7 @@ describe('FixedPointNumber class tests', () => {
             const y = FixedPointNumber.of(3);
             const actual = x.div(y);
             const expected = BigNumber(x.n).div(BigNumber(y.n));
-            const dp = -5; // BigNumber default precision diverges after 15 digits.
-            expect(actual.toString().slice(0, dp)).toBe(
-                expected.toString().slice(0, dp)
-            );
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('x / y = real', () => {
@@ -733,10 +730,7 @@ describe('FixedPointNumber class tests', () => {
             const y = FixedPointNumber.of(113);
             const actual = x.div(y);
             const expected = BigNumber(x.n).div(BigNumber(y.n));
-            const dp = -5; // BigNumber default precision diverges after 15 digits.
-            expect(actual.toString().slice(0, dp)).toBe(
-                expected.toString().slice(0, dp)
-            );
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('x / y = integer', () => {
@@ -744,7 +738,7 @@ describe('FixedPointNumber class tests', () => {
             const y = FixedPointNumber.of(-5);
             const actual = x.div(y);
             const expected = BigNumber(x.n).div(BigNumber(y.n));
-            expect(actual.n).toBe(expected.toNumber());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('x / 1 = x scale test', () => {
@@ -767,15 +761,15 @@ describe('FixedPointNumber class tests', () => {
             const r = 0;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
-        test('NaN / n = ', () => {
+        test('NaN / n -> NaN', () => {
             const l = NaN;
             const r = 123.45;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
         test('-Infinite / ±Infinite -> NaN', () => {
@@ -841,7 +835,7 @@ describe('FixedPointNumber class tests', () => {
             const r = NaN;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
         test('n / -Infinity = 0', () => {
@@ -849,7 +843,7 @@ describe('FixedPointNumber class tests', () => {
             const r = -Infinity;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('n / +Infinity = 0', () => {
@@ -857,7 +851,7 @@ describe('FixedPointNumber class tests', () => {
             const r = Infinity;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('-n / 0 = -Infinity', () => {
@@ -865,7 +859,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 0;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('+n / 0 = +Infinity', () => {
@@ -873,7 +867,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 0;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('n / integer', () => {
@@ -881,7 +875,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 3;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('n / rational', () => {
@@ -889,7 +883,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 0.7;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('x / 1 = x scale test', () => {
@@ -903,7 +897,7 @@ describe('FixedPointNumber class tests', () => {
             );
             const expected = BigNumber(x).idiv(BigNumber(y));
             expect(actualUp.isEqual(actualDn)).toBe(true);
-            expect(actualDn.toString()).toBe(expected.toString());
+            expect(actualUp.n).toBeCloseTo(expected.toNumber());
         });
     });
 
@@ -1935,7 +1929,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 0;
             const actual = FixedPointNumber.of(l).minus(FixedPointNumber.of(r));
             const expected = BigNumber(l).minus(BigNumber(r));
-            expect(actual.n).toBe(expected.toNumber());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
             expect(actual.eq(FixedPointNumber.of(l))).toBe(true);
         });
 
@@ -1959,7 +1953,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 23.45678;
             const actual = FixedPointNumber.of(l).minus(FixedPointNumber.of(r));
             const expected = BigNumber(l).minus(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('l - r -> <0', () => {
@@ -1967,7 +1961,7 @@ describe('FixedPointNumber class tests', () => {
             const r = -1234.5678;
             const actual = FixedPointNumber.of(l).minus(FixedPointNumber.of(r));
             const expected = BigNumber(l).minus(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
     });
 
@@ -2078,7 +2072,7 @@ describe('FixedPointNumber class tests', () => {
                 FixedPointNumber.of(r)
             );
             const expected = BigNumber(l).modulo(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('n % ±1 -> 0 - scale test', () => {
@@ -2219,7 +2213,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 0;
             const actual = FixedPointNumber.of(l).plus(FixedPointNumber.of(r));
             const expected = BigNumber(l).plus(BigNumber(r));
-            expect(actual.n).toBe(expected.toNumber());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
             expect(actual.eq(FixedPointNumber.of(l))).toBe(true);
         });
 
@@ -2245,7 +2239,7 @@ describe('FixedPointNumber class tests', () => {
             const actual = FixedPointNumber.of(l).plus(FixedPointNumber.of(r));
             const expected = BigNumber(l).plus(BigNumber(r));
             expect(actual.n.toFixed(fd)).toBe(expected.toNumber().toFixed(fd));
-            expect(actual.n).toBe(l + r);
+            expect(actual.n).toBeCloseTo(l + r);
         });
     });
 
@@ -2399,8 +2393,7 @@ describe('FixedPointNumber class tests', () => {
             const e = -2;
             const expected = BigNumber(b).pow(BigNumber(e));
             const actual = FixedPointNumber.of(b).pow(FixedPointNumber.of(e));
-            console.log(actual.toString());
-            console.log(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('-b ^ +e', () => {
@@ -2408,7 +2401,7 @@ describe('FixedPointNumber class tests', () => {
             const e = 7;
             const expected = BigNumber(b).pow(BigNumber(e));
             const actual = FixedPointNumber.of(b).pow(FixedPointNumber.of(e));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('+b ^ +e', () => {
@@ -2416,7 +2409,7 @@ describe('FixedPointNumber class tests', () => {
             const e = 8;
             const expected = BigNumber(b).pow(BigNumber(e));
             const actual = FixedPointNumber.of(b).pow(FixedPointNumber.of(e));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('-b ^ 0 = 1', () => {
@@ -2444,8 +2437,9 @@ describe('FixedPointNumber class tests', () => {
             const jsA = interestWithNumberType(P, R, N, T);
             const bnA = interestWithBigNumberType(P, R, N, T);
             const fpA = interestWithFixedPointNumberType(P, R, N, T);
-            expect(fpA.toString()).toBe(jsA.toString());
-            expect(fpA.toString()).toBe(bnA.toString());
+            expect(fpA.n).toBeCloseTo(jsA);
+            expect(fpA.n).toBeCloseTo(jsA);
+            expect(fpA.n).toBeCloseTo(bnA.toNumber());
         });
 
         test('compound interest - once per day', () => {
@@ -2456,8 +2450,8 @@ describe('FixedPointNumber class tests', () => {
             const jsA = interestWithNumberType(P, R, N, T);
             const bnA = interestWithBigNumberType(P, R, N, T);
             const fpA = interestWithFixedPointNumberType(P, R, N, T);
-            expect(fpA.toString()).not.toBe(jsA.toString());
-            expect(fpA.toString()).not.toBe(bnA.toString());
+            expect(fpA.n).not.toBe(jsA);
+            expect(fpA.n).toBeCloseTo(bnA.toNumber());
         });
     });
 
@@ -2621,27 +2615,27 @@ describe('FixedPointNumber class tests', () => {
         test('< 1', () => {
             const expected = 0.0001;
             const actual = FixedPointNumber.of(expected);
-            expect(actual.toString()).toEqual(expected.toString());
+            expect(actual.n).toBeCloseTo(expected);
         });
         test('> 1', () => {
             const expected = 123.456;
             const actual = FixedPointNumber.of(123.456);
-            expect(actual.toString()).toEqual(expected.toString());
+            expect(actual.n).toBeCloseTo(expected);
         });
         test('NaN', () => {
             const expected = Number.NaN;
             const actual = FixedPointNumber.of(expected);
-            expect(actual.toString()).toEqual(expected.toString());
+            expect(actual.n).toBe(expected);
         });
         test('-Infinity', () => {
             const expected = -Infinity;
             const actual = FixedPointNumber.of(-Infinity);
-            expect(actual.toString()).toEqual(expected.toString());
+            expect(actual.n).toBeCloseTo(expected);
         });
         test('+Infinity', () => {
             const expected = -Infinity;
             const actual = FixedPointNumber.of(expected);
-            expect(actual.toString()).toEqual(expected.toString());
+            expect(actual.n).toBeCloseTo(expected);
         });
     });
 });


### PR DESCRIPTION
# Description

The tests at `packages/core/tests/vcdm/FixedPointNumber.unit.test.ts` compares fixed point precision numbers with floating point precision numbers. Equality tests must admit a range of approximation since JS `number` type IEEE 754 approximate results of rational values.

Recent JS runtime changes (NodeJS v24) changed the approximation logic in string rendering, hence few tests didn't work anymore.

**The tests use https://jestjs.io/docs/expect#tobeclosetonumber-numdigits to unify the legitimate approximation logic.**

Fixes #2075

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `yarn test:solo`
- [x] `yarn test:unit`

**Test Configuration**:
* Node.js Version: v24.0.0
* Yarn Version: 1.22.22
