### PR TITLE
1962 fix(network): AccountsModule floating point unit test

### DIFF
--- a/packages/network/tests/thor-client/accounts/AccountsModule.solo.test.ts
+++ b/packages/network/tests/thor-client/accounts/AccountsModule.solo.test.ts
@@ -64,8 +64,8 @@ describe('AccountsModule solo tests', () => {
 
                 expect(later).toBeDefined();
                 expect(later.balance).toEqual(ahead.balance);
-                expect(Number(later.energy)).toBeGreaterThan(
-                    Number(ahead.energy)
+                expect(BigInt(later.energy)).toBeGreaterThan(
+                    BigInt(ahead.energy)
                 );
             },
             TIMEOUT


### PR DESCRIPTION
# Description

Updates the `AccountsModule` test to use `BigInt` instead of `Number` to assure floating point precision.

Fixes #1962

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run `npm run test-solo` within the `network` package, no errors should be thrown for the `AccountsModule.solo.test`.

**Test Configuration**:
* Node.js Version: v21.1.0
* Yarn Version:

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test assertions to accurately compare large integer values for account energy using precise BigInt conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->