### PR TITLE
2080 fix(gas): gas not to be decimal when using gasPadding

### DIFF
--- a/packages/network/src/thor-client/transactions/transactions-module.ts
+++ b/packages/network/src/thor-client/transactions/transactions-module.ts
@@ -771,11 +771,11 @@ class TransactionsModule {
 
         // The total gas of the transaction
         // If the transaction involves contract interaction, a constant 15000 gas is added to the total gas
-        const totalGas =
+        const totalGas = Math.ceil(
             (intrinsicGas +
                 (totalSimulatedGas !== 0 ? totalSimulatedGas + 15000 : 0)) *
-            (1 + (options?.gasPadding ?? 0)); // Add gasPadding if it is defined
-
+                (1 + (options?.gasPadding ?? 0))
+        ); // Add gasPadding if it is defined
         return isReverted
             ? {
                   totalGas,

--- a/packages/network/tests/thor-client/gas/fixture.ts
+++ b/packages/network/tests/thor-client/gas/fixture.ts
@@ -289,6 +289,32 @@ const estimateGasTestCases = {
                 revertReasons: [],
                 vmErrors: []
             }
+        },
+        {
+            description:
+                'Should estimate gas cost correct and have an integer as gas, when gasPadding should add a decimal',
+            clauses: [
+                {
+                    to: TEST_ACCOUNTS.TRANSACTION.TRANSACTION_RECEIVER.address,
+                    value: Units.parseEther('1').toString(),
+                    data: '0x'
+                },
+                {
+                    to: TEST_ACCOUNTS.TRANSACTION.TRANSACTION_RECEIVER.address,
+                    value: Units.parseEther('1').toString(),
+                    data: '0x'
+                }
+            ],
+            caller: TEST_ACCOUNTS.TRANSACTION.TRANSACTION_SENDER.address,
+            options: {
+                gasPadding: 0.113458 // 11.3458%
+            },
+            expected: {
+                reverted: false,
+                totalGas: 41198, // 37000 + 11.3458% = 41197.946
+                revertReasons: [],
+                vmErrors: []
+            }
         }
     ]
 };


### PR DESCRIPTION
# Description

When estimating gas, and also using `gasPadding` the `totalGas` could be a decimal for a very rare value for `gasPadding` (e.g.: 0.1234). In this case we want to make sure that the estimated gas will not be a decimal, but an integer – given that you the gas for a transaction needs to be an integer.

Used `Math.ceil()` in order to convert the gas to an integer by hitting the upper int. I have chosen this over `Number` or `Math.floor()` because the amount of gas added is insignificant, and we make sure that we are hitting the gasPadding expected.

Fixes #2080

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Wrote a solo test for `gas.solo`.

**Test Configuration**:
* Node.js Version: v21.1.0
* Yarn Version:

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code