### PR TITLE
fix: nonce validation

### DIFF
--- a/packages/network/src/signer/signers/utils/utils.ts
+++ b/packages/network/src/signer/signers/utils/utils.ts
@@ -8,11 +8,24 @@ import { type TransactionRequestInput } from '../types';
  * @param from - The address of the sender
  *
  * @returns The transaction request input
+ * @throws Error if nonce is negative
  */
 function transactionBodyToTransactionRequestInput(
     transactionBody: TransactionBody,
     from: string
 ): TransactionRequestInput {
+    // Validate that nonce is not negative
+    if (transactionBody.nonce !== undefined) {
+        const nonceValue =
+            typeof transactionBody.nonce === 'string'
+                ? parseInt(transactionBody.nonce, 10)
+                : transactionBody.nonce;
+
+        if (nonceValue < 0) {
+            throw new Error('Transaction nonce must be a positive number');
+        }
+    }
+
     return {
         from,
         chainTag: transactionBody.chainTag,


### PR DESCRIPTION
# Description

Added nonce value validation, if the nonce value is not positive, an error will be thrown.

Fixes # 2043

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x]  Pass a negative value to nonce into signerUtils.transactionBodyToTransactionRequestInput

**Test Configuration**:
* Node.js Version:
* Yarn Version:

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for transaction requests to prevent negative nonce values, ensuring more reliable transaction processing.
- **Documentation**
	- Updated documentation to clarify error handling for invalid nonce values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->