### PR TITLE
2116 bug   simulatetransaction doesnt return what expected

### DIFF
--- a/packages/network/src/thor-client/transactions/types.d.ts
+++ b/packages/network/src/thor-client/transactions/types.d.ts
@@ -302,6 +302,26 @@ interface TransactionReceipt {
 }
 
 /**
+ * [Event](http://localhost:8669/doc/stoplight-ui/#/schemas/Event)
+ */
+interface TransactionSimulationEvent {
+    /**
+     * The address of the contract that emitted the event.
+     */
+    address: string;
+
+    /**
+     * Topics are indexed parameters to an event. The first topic is always the event signature.
+     */
+    topics: string[];
+
+    /**
+     * The data associated with the event.
+     */
+    data: string;
+}
+
+/**
  * Type for transaction call simulation result.
  */
 interface TransactionSimulationResult {
@@ -312,7 +332,7 @@ interface TransactionSimulationResult {
     /**
      * Events emitted from the transaction simulation
      */
-    events: Event[];
+    events: TransactionSimulationEvent[];
     /**
      * Transfers that occur from the transaction simulation
      */
@@ -334,17 +354,18 @@ interface TransactionSimulationResult {
 /* --- Responses Outputs end --- */
 
 export type {
-    WaitForTransactionOptions,
-    TransactionBodyOptions,
-    SignTransactionOptions,
     GetDelegationSignatureResult,
-    SendTransactionResult,
     GetTransactionInputOptions,
     GetTransactionReceiptInputOptions,
-    TransactionReceipt,
-    TransactionSimulationResult,
+    SendTransactionResult,
+    SignTransactionOptions,
     SimulateTransactionClause,
     SimulateTransactionOptions,
+    TransactionBodyOptions,
+    TransactionDetailNoRaw,
     TransactionDetailRaw,
-    TransactionDetailNoRaw
+    TransactionReceipt,
+    TransactionSimulationEvent,
+    TransactionSimulationResult,
+    WaitForTransactionOptions
 };


### PR DESCRIPTION
# Description

The interface `TransactionSimulationResult` in `packages/network/src/thor-client/transactions/types.d.ts` exposed the property `events: Event` where the type referred to [DOM Event](https://developer.mozilla.org/en-US/docs/Web/API/Event), obviously not the [Thor Event](https://mainnet.vechain.org/doc/stoplight-ui/#/schemas/Event).

The fix introduces the `TransactionSimulationEvent` interface and changes property `events: TransactionSimulationEvent[]` of `TransactionSimulationResult` in `packages/network/src/thor-client/transactions/types.d.ts`.

Fixes #2116

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `yarn test:solo`

**Test Configuration**:
* Node.js Version: v24.0.0
* Yarn Version: 1.22.22
