### PR TITLE
2158 fixed precision number tests fix

### DIFF
--- a/packages/core/src/vcdm/FixedPointNumber.ts
+++ b/packages/core/src/vcdm/FixedPointNumber.ts
@@ -1,5 +1,5 @@
 import { IllegalArgumentError, UnsupportedOperationError } from '@errors';
-import { Txt, type VeChainDataModel  } from '@vcdm';
+import { Txt, type VeChainDataModel } from '@vcdm';
 
 /**
  * Full Qualified Path
@@ -223,7 +223,7 @@ class FixedPointNumber implements VeChainDataModel<FixedPointNumber> {
      * -1, 0, or 1 if this instance is less than, equal to, or greater
      * than the specified instance, respectively.
      *
-     * @remarks This method uses internally {@link compareTo} wrapping the {@link InvalidOperation} exception
+     * @remarks This method uses internally {@link compareTo} wrapping the {@link UnsupportedOperationError} exception
      * when comparing between {@link NaN} values to behave according the
      * [[bignumber.js comparedTo](https://mikemcl.github.io/bignumber.js/#cmp)] rules.
      */
@@ -256,25 +256,22 @@ class FixedPointNumber implements VeChainDataModel<FixedPointNumber> {
      */
     public div(that: FixedPointNumber): FixedPointNumber {
         if (this.isNaN() || that.isNaN()) return FixedPointNumber.NaN;
-        if (this.isNegativeInfinite())
-            return that.isInfinite()
-                ? FixedPointNumber.NaN
-                : that.isPositive()
-                  ? FixedPointNumber.NEGATIVE_INFINITY
-                  : FixedPointNumber.POSITIVE_INFINITY;
-        if (this.isPositiveInfinite())
-            return that.isInfinite()
-                ? FixedPointNumber.NaN
-                : that.isPositive()
-                  ? FixedPointNumber.POSITIVE_INFINITY
-                  : FixedPointNumber.NEGATIVE_INFINITY;
+        if (this.isNegativeInfinite()) {
+            if (that.isInfinite()) return FixedPointNumber.NaN;
+            if (that.isPositive()) return FixedPointNumber.NEGATIVE_INFINITY;
+            return FixedPointNumber.POSITIVE_INFINITY;
+        }
+        if (this.isPositiveInfinite()) {
+            if (that.isInfinite()) return FixedPointNumber.NaN;
+            if (that.isPositive()) return FixedPointNumber.POSITIVE_INFINITY;
+            return FixedPointNumber.NEGATIVE_INFINITY;
+        }
         if (that.isInfinite()) return FixedPointNumber.ZERO;
-        if (that.isZero())
-            return this.isZero()
-                ? FixedPointNumber.NaN
-                : this.isNegative()
-                  ? FixedPointNumber.NEGATIVE_INFINITY
-                  : FixedPointNumber.POSITIVE_INFINITY;
+        if (that.isZero()) {
+            if (this.isZero()) return FixedPointNumber.NaN;
+            if (this.isNegative()) return FixedPointNumber.NEGATIVE_INFINITY;
+            return FixedPointNumber.POSITIVE_INFINITY;
+        }
         const fd = this.maxFractionalDigits(that, this.fractionalDigits); // Max common fractional decimals.
         return new FixedPointNumber(
             fd,
@@ -401,25 +398,22 @@ class FixedPointNumber implements VeChainDataModel<FixedPointNumber> {
      */
     public idiv(that: FixedPointNumber): FixedPointNumber {
         if (this.isNaN() || that.isNaN()) return FixedPointNumber.NaN;
-        if (this.isNegativeInfinite())
-            return that.isInfinite()
-                ? FixedPointNumber.NaN
-                : that.isPositive()
-                  ? FixedPointNumber.NEGATIVE_INFINITY
-                  : FixedPointNumber.POSITIVE_INFINITY;
-        if (this.isPositiveInfinite())
-            return that.isInfinite()
-                ? FixedPointNumber.NaN
-                : that.isPositive()
-                  ? FixedPointNumber.POSITIVE_INFINITY
-                  : FixedPointNumber.NEGATIVE_INFINITY;
+        if (this.isNegativeInfinite()) {
+            if (that.isInfinite()) return FixedPointNumber.NaN;
+            if (that.isPositive()) return FixedPointNumber.NEGATIVE_INFINITY;
+            return FixedPointNumber.POSITIVE_INFINITY;
+        }
+        if (this.isPositiveInfinite()) {
+            if (that.isInfinite()) return FixedPointNumber.NaN;
+            if (that.isPositive()) return FixedPointNumber.POSITIVE_INFINITY;
+            return FixedPointNumber.NEGATIVE_INFINITY;
+        }
         if (that.isInfinite()) return FixedPointNumber.ZERO;
-        if (that.isZero())
-            return this.isZero()
-                ? FixedPointNumber.NaN
-                : this.isNegative()
-                  ? FixedPointNumber.NEGATIVE_INFINITY
-                  : FixedPointNumber.POSITIVE_INFINITY;
+        if (that.isZero()) {
+            if (this.isZero()) return FixedPointNumber.NaN;
+            if (this.isNegative()) return FixedPointNumber.NEGATIVE_INFINITY;
+            return FixedPointNumber.POSITIVE_INFINITY;
+        }
         const fd = this.maxFractionalDigits(that, this.fractionalDigits); // Max common fractional decimals.
         return new FixedPointNumber(
             fd,
@@ -652,13 +646,13 @@ class FixedPointNumber implements VeChainDataModel<FixedPointNumber> {
      * If the maximum fixed digits value is less than `minFixedDigits`, return `minFixedDigits`.
      *
      * @param {FixedPointNumber} that to evaluate if `that` has the maximum fixed digits value.
-     * @param {bigint} minFixedDigits Min value of returned value, {@link FixedPointNumber.DEFAULT_FRACTIONAL_DECIMALS} by default.
+     * @param {bigint} minFixedDigits Min value of returned value.
      *
      * @return the greater fixed digits value among `this`, `that` and `minFixedDigits`.
      */
     private maxFractionalDigits(
         that: FixedPointNumber,
-        minFixedDigits: bigint = FixedPointNumber.DEFAULT_FRACTIONAL_DECIMALS
+        minFixedDigits: bigint
     ): bigint {
         const fd =
             this.fractionalDigits < that.fractionalDigits
@@ -962,7 +956,7 @@ class FixedPointNumber implements VeChainDataModel<FixedPointNumber> {
                 this.fractionalDigits,
                 FixedPointNumber.sqr(this.scaledValue, this.fractionalDigits)
             );
-        } catch (e) {
+        } catch {
             return FixedPointNumber.NaN;
         }
     }

--- a/packages/core/tests/vcdm/FixedPointNumber.unit.test.ts
+++ b/packages/core/tests/vcdm/FixedPointNumber.unit.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, test } from '@jest/globals';
 import log from 'loglevel';
 import { BigNumber } from 'bignumber.js';
-import {
-    FixedPointNumber,
-    Txt,
-} from '@vcdm';
+import { FixedPointNumber, Txt } from '@vcdm';
 import { IllegalArgumentError, UnsupportedOperationError } from '@errors';
 
 /**
@@ -68,8 +65,8 @@ describe('FixedPointNumber class tests', () => {
 
             test('±n', () => {
                 const n = 123.45;
-                expect(FixedPointNumber.of(n).n).toEqual(n);
-                expect(FixedPointNumber.of(-n).n).toEqual(-n);
+                expect(FixedPointNumber.of(n).n).toBeCloseTo(n);
+                expect(FixedPointNumber.of(-n).n).toBeCloseTo(-n);
             });
         });
 
@@ -341,35 +338,35 @@ describe('FixedPointNumber class tests', () => {
             const n = NaN;
             const actual = FixedPointNumber.of(n);
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.toString()).toBe(n.toString());
+            expect(actual.n).toBe(n);
         });
 
         test('of -Infinity', () => {
             const n = -Infinity;
             const actual = FixedPointNumber.of(n);
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.toString()).toBe(n.toString());
+            expect(actual.n).toBe(n);
         });
 
         test('of +Infinity', () => {
             const n = Infinity;
             const actual = FixedPointNumber.of(n);
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.toString()).toBe(n.toString());
+            expect(actual.n).toBe(n);
         });
 
         test('of -bigint', () => {
             const bi = -12345678901234567890n;
             const actual = FixedPointNumber.of(bi);
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.toString()).toBe(bi.toString());
+            expect(actual.bi).toBe(bi);
         });
 
         test('of +bigint', () => {
             const bi = 12345678901234567890n;
             const actual = FixedPointNumber.of(bi);
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.toString()).toBe(bi.toString());
+            expect(actual.bi).toBe(bi);
         });
 
         test('of FixedPointNumber', () => {
@@ -382,28 +379,28 @@ describe('FixedPointNumber class tests', () => {
             const n = 123.0067;
             const actual = FixedPointNumber.of(n);
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.toString()).toBe(n.toString());
+            expect(actual.n).toBeCloseTo(n);
         });
 
         test('of -n', () => {
             const n = -123.0067;
             const actual = FixedPointNumber.of(n);
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.toString()).toBe(n.toString());
+            expect(actual.n).toBeCloseTo(n);
         });
 
         test('of negative string', () => {
             const n = '-123.0067';
             const actual = FixedPointNumber.of(n.toString());
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.toString()).toBe(n.toString());
+            expect(actual.n).toBeCloseTo(Number(n));
         });
 
         test('of positive string', () => {
             const exp = '+123.45';
             const actual = FixedPointNumber.of(exp);
             expect(actual).toBeInstanceOf(FixedPointNumber);
-            expect(actual.n).toBe(Number(exp));
+            expect(actual.n).toBeCloseTo(Number(exp));
         });
 
         test('of an illegal expression throws exception', () => {
@@ -435,14 +432,14 @@ describe('FixedPointNumber class tests', () => {
             const n = -0.8;
             const actual = FixedPointNumber.of(n).abs();
             const expected = BigNumber(n).abs();
-            expect(actual.n).toEqual(expected.toNumber());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('n > 0', () => {
             const n = 0.8;
             const actual = FixedPointNumber.of(n).abs();
             const expected = BigNumber(n).abs();
-            expect(actual.n).toEqual(expected.toNumber());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
     });
 
@@ -606,6 +603,12 @@ describe('FixedPointNumber class tests', () => {
             const actual = FixedPointNumber.of(n).dp(fd);
             expect(actual.isEqual(expected)).toBe(true);
         });
+
+        test(' scale negative -> err', () => {
+            expect(() => {
+                FixedPointNumber.of(123.45).dp(-1n);
+            }).toThrow(IllegalArgumentError);
+        });
     });
 
     describe('div method tests', () => {
@@ -614,7 +617,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 0;
             const actual = FixedPointNumber.of(lr).div(FixedPointNumber.of(r));
             const expected = BigNumber(lr).div(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
         test('NaN / n = ', () => {
@@ -622,7 +625,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 123.45;
             const actual = FixedPointNumber.of(lr).div(FixedPointNumber.of(r));
             const expected = BigNumber(lr).div(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
         test('-Infinite / ±Infinite -> NaN', () => {
@@ -649,8 +652,8 @@ describe('FixedPointNumber class tests', () => {
         test('-Infinite / +n -> -Infinite', () => {
             expect(
                 FixedPointNumber.NEGATIVE_INFINITY.div(
-                    FixedPointNumber.of(-123.45)
-                ).isPositive()
+                    FixedPointNumber.of(123.45)
+                ).isNegativeInfinite()
             ).toBe(true);
         });
 
@@ -688,7 +691,7 @@ describe('FixedPointNumber class tests', () => {
             const y = FixedPointNumber.of(NaN);
             const actual = x.div(y);
             const expected = BigNumber(x.n).div(BigNumber(y.n));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
         test('n / -Infinity = 0', () => {
@@ -696,7 +699,7 @@ describe('FixedPointNumber class tests', () => {
             const r = -Infinity;
             const actual = FixedPointNumber.of(lr).div(FixedPointNumber.of(r));
             const expected = BigNumber(lr).div(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('n / +Infinity = 0', () => {
@@ -704,7 +707,7 @@ describe('FixedPointNumber class tests', () => {
             const r = Infinity;
             const actual = FixedPointNumber.of(lr).div(FixedPointNumber.of(r));
             const expected = BigNumber(lr).div(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
         test('-n / 0 = -Infinity', () => {
@@ -712,7 +715,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 0;
             const actual = FixedPointNumber.of(lr).div(FixedPointNumber.of(r));
             const expected = BigNumber(lr).div(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
         test('+n / 0 = +Infinity', () => {
@@ -720,7 +723,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 0;
             const actual = FixedPointNumber.of(lr).div(FixedPointNumber.of(r));
             const expected = BigNumber(lr).div(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
         test('x / y = periodic', () => {
@@ -728,10 +731,7 @@ describe('FixedPointNumber class tests', () => {
             const y = FixedPointNumber.of(3);
             const actual = x.div(y);
             const expected = BigNumber(x.n).div(BigNumber(y.n));
-            const dp = -5; // BigNumber default precision diverges after 15 digits.
-            expect(actual.toString().slice(0, dp)).toBe(
-                expected.toString().slice(0, dp)
-            );
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('x / y = real', () => {
@@ -739,10 +739,7 @@ describe('FixedPointNumber class tests', () => {
             const y = FixedPointNumber.of(113);
             const actual = x.div(y);
             const expected = BigNumber(x.n).div(BigNumber(y.n));
-            const dp = -5; // BigNumber default precision diverges after 15 digits.
-            expect(actual.toString().slice(0, dp)).toBe(
-                expected.toString().slice(0, dp)
-            );
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('x / y = integer', () => {
@@ -750,7 +747,7 @@ describe('FixedPointNumber class tests', () => {
             const y = FixedPointNumber.of(-5);
             const actual = x.div(y);
             const expected = BigNumber(x.n).div(BigNumber(y.n));
-            expect(actual.n).toBe(expected.toNumber());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('x / 1 = x scale test', () => {
@@ -773,15 +770,15 @@ describe('FixedPointNumber class tests', () => {
             const r = 0;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
-        test('NaN / n = ', () => {
+        test('NaN / n -> NaN', () => {
             const l = NaN;
             const r = 123.45;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
         test('-Infinite / ±Infinite -> NaN', () => {
@@ -808,8 +805,8 @@ describe('FixedPointNumber class tests', () => {
         test('-Infinite / +n -> -Infinite', () => {
             expect(
                 FixedPointNumber.NEGATIVE_INFINITY.idiv(
-                    FixedPointNumber.of(-123.45)
-                ).isPositiveInfinite()
+                    FixedPointNumber.of(123.45)
+                ).isNegativeInfinite()
             ).toBe(true);
         });
 
@@ -847,7 +844,7 @@ describe('FixedPointNumber class tests', () => {
             const r = NaN;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBe(expected.toNumber());
         });
 
         test('n / -Infinity = 0', () => {
@@ -855,7 +852,7 @@ describe('FixedPointNumber class tests', () => {
             const r = -Infinity;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('n / +Infinity = 0', () => {
@@ -863,7 +860,7 @@ describe('FixedPointNumber class tests', () => {
             const r = Infinity;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('-n / 0 = -Infinity', () => {
@@ -871,7 +868,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 0;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('+n / 0 = +Infinity', () => {
@@ -879,7 +876,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 0;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('n / integer', () => {
@@ -887,7 +884,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 3;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('n / rational', () => {
@@ -895,7 +892,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 0.7;
             const actual = FixedPointNumber.of(l).idiv(FixedPointNumber.of(r));
             const expected = BigNumber(l).idiv(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('x / 1 = x scale test', () => {
@@ -909,7 +906,7 @@ describe('FixedPointNumber class tests', () => {
             );
             const expected = BigNumber(x).idiv(BigNumber(y));
             expect(actualUp.isEqual(actualDn)).toBe(true);
-            expect(actualDn.toString()).toBe(expected.toString());
+            expect(actualUp.n).toBeCloseTo(expected.toNumber());
         });
     });
 
@@ -1941,7 +1938,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 0;
             const actual = FixedPointNumber.of(l).minus(FixedPointNumber.of(r));
             const expected = BigNumber(l).minus(BigNumber(r));
-            expect(actual.n).toBe(expected.toNumber());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
             expect(actual.eq(FixedPointNumber.of(l))).toBe(true);
         });
 
@@ -1965,7 +1962,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 23.45678;
             const actual = FixedPointNumber.of(l).minus(FixedPointNumber.of(r));
             const expected = BigNumber(l).minus(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('l - r -> <0', () => {
@@ -1973,7 +1970,7 @@ describe('FixedPointNumber class tests', () => {
             const r = -1234.5678;
             const actual = FixedPointNumber.of(l).minus(FixedPointNumber.of(r));
             const expected = BigNumber(l).minus(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
     });
 
@@ -2084,7 +2081,7 @@ describe('FixedPointNumber class tests', () => {
                 FixedPointNumber.of(r)
             );
             const expected = BigNumber(l).modulo(BigNumber(r));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('n % ±1 -> 0 - scale test', () => {
@@ -2225,7 +2222,7 @@ describe('FixedPointNumber class tests', () => {
             const r = 0;
             const actual = FixedPointNumber.of(l).plus(FixedPointNumber.of(r));
             const expected = BigNumber(l).plus(BigNumber(r));
-            expect(actual.n).toBe(expected.toNumber());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
             expect(actual.eq(FixedPointNumber.of(l))).toBe(true);
         });
 
@@ -2251,7 +2248,7 @@ describe('FixedPointNumber class tests', () => {
             const actual = FixedPointNumber.of(l).plus(FixedPointNumber.of(r));
             const expected = BigNumber(l).plus(BigNumber(r));
             expect(actual.n.toFixed(fd)).toBe(expected.toNumber().toFixed(fd));
-            expect(actual.n).toBe(l + r);
+            expect(actual.n).toBeCloseTo(l + r);
         });
     });
 
@@ -2405,7 +2402,7 @@ describe('FixedPointNumber class tests', () => {
             const e = -2;
             const expected = BigNumber(b).pow(BigNumber(e));
             const actual = FixedPointNumber.of(b).pow(FixedPointNumber.of(e));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('-b ^ +e', () => {
@@ -2413,7 +2410,7 @@ describe('FixedPointNumber class tests', () => {
             const e = 7;
             const expected = BigNumber(b).pow(BigNumber(e));
             const actual = FixedPointNumber.of(b).pow(FixedPointNumber.of(e));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('+b ^ +e', () => {
@@ -2421,7 +2418,7 @@ describe('FixedPointNumber class tests', () => {
             const e = 8;
             const expected = BigNumber(b).pow(BigNumber(e));
             const actual = FixedPointNumber.of(b).pow(FixedPointNumber.of(e));
-            expect(actual.toString()).toBe(expected.toString());
+            expect(actual.n).toBeCloseTo(expected.toNumber());
         });
 
         test('-b ^ 0 = 1', () => {
@@ -2449,8 +2446,9 @@ describe('FixedPointNumber class tests', () => {
             const jsA = interestWithNumberType(P, R, N, T);
             const bnA = interestWithBigNumberType(P, R, N, T);
             const fpA = interestWithFixedPointNumberType(P, R, N, T);
-            expect(fpA.toString()).toBe(jsA.toString());
-            expect(fpA.toString()).toBe(bnA.toString());
+            expect(fpA.n).toBeCloseTo(jsA);
+            expect(fpA.n).toBeCloseTo(jsA);
+            expect(fpA.n).toBeCloseTo(bnA.toNumber());
         });
 
         test('compound interest - once per day', () => {
@@ -2461,8 +2459,8 @@ describe('FixedPointNumber class tests', () => {
             const jsA = interestWithNumberType(P, R, N, T);
             const bnA = interestWithBigNumberType(P, R, N, T);
             const fpA = interestWithFixedPointNumberType(P, R, N, T);
-            expect(fpA.toString()).not.toBe(jsA.toString());
-            expect(fpA.toString()).not.toBe(bnA.toString());
+            expect(fpA.n).not.toBe(jsA);
+            expect(fpA.n).toBeCloseTo(bnA.toNumber());
         });
     });
 
@@ -2646,6 +2644,11 @@ describe('FixedPointNumber class tests', () => {
         test('+Infinity', () => {
             const expected = -Infinity;
             const actual = FixedPointNumber.of(expected);
+            expect(actual.toString()).toEqual(expected.toString());
+        });
+        test('no fractional digits', () => {
+            const expected = 123;
+            const actual = FixedPointNumber.of(expected, 0n);
             expect(actual.toString()).toEqual(expected.toString());
         });
     });


### PR DESCRIPTION
# Description

The tests at `packages/core/tests/vcdm/FixedPointNumber.unit.test.ts` adapted to updated **jest** paradigm to compare approximated results of IEEE-754 floating point numbers and fixed point numbers. 

Fixes #2158

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `yarn test:unit`
- [x] `yarn test:solo`

**Test Configuration**:
* Node.js Version: v24.0.0
* Yarn Version: 1.22.22
