### PR TITLE
chore(hh-integration): removed `galactica_devnet` script

### DIFF
--- a/apps/sdk-hardhat-integration/package.json
+++ b/apps/sdk-hardhat-integration/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "compile": "npx hardhat compile",
     "test": "npx hardhat test --network vechain_testnet",
-    "test:galactica:devnet": "npx hardhat test --network vechain_galactica_devnet",
     "deploy-solo": "npx hardhat run scripts/deploy.ts --network vechain_solo",
     "deploy-testnet": "npx hardhat run scripts/deploy.ts --network vechain_testnet",
     "deploy-erc20": "npx hardhat run scripts/erc20/deploy.ts --network vechain_testnet",


### PR DESCRIPTION
# Description

Removed script since it is not used and does not refer to an existing configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the script for running tests on the "vechain_galactica_devnet" network from available npm commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->