### PR TITLE
fix: 1982

### DIFF
--- a/packages/network/tests/thor-client/accounts/AccountsModule.solo.test.ts
+++ b/packages/network/tests/thor-client/accounts/AccountsModule.solo.test.ts
@@ -19,20 +19,17 @@ const TIMEOUT = 20000;
 describe('AccountsModule solo tests', () => {
     const thorClient = ThorClient.at(THOR_SOLO_URL);
 
-    describe('getByteCode method tests', () => {
-        test(
-            'ok <- contract address',
-            async () => {
-                const actual = await retryOperation(async () => {
-                    return await thorClient.accounts.getBytecode(
-                        Address.of(CONTRACT_ADDRESS)
-                    );
-                });
-                expect(
-                    actual.isEqual(Hex.of(configData.TESTING_CONTRACT_BYTECODE))
-                ).toBe(true);
-            },
-            TIMEOUT
-        );
-    });
+    test(
+        'ok <- contract address',
+        async () => {
+            const expected = Hex.of(configData.TESTING_CONTRACT_BYTECODE);
+            const actual = await retryOperation(async () => {
+                return await thorClient.accounts.getBytecode(
+                    Address.of(CONTRACT_ADDRESS)
+                );
+            });
+            expect(actual).toEqual(expected);
+        },
+        TIMEOUT
+    );
 });


### PR DESCRIPTION
# Description

Test at AccountsModule.solo.test.ts was ill designed because comparing a `String` type with eventually hexadecimal content with an instance of `Hex` class. This is a very common mistake induced by the syntactical element of t he JS language, not typed, because strings can have an hex content, those are not expressing array of bytes as hexadecimal types are used to express. VeChain introduced it's data model and the `Hex` hierarchy of classes precisely to address the ambiguity JS promotes and TS doesn't heal completely.

The bug is originated by the test code because the former `CONTRACT_BYTECODE`, now `configData.TESTING_CONTRACT_BYTECODE` is a string expressing an hexadecimal content, not an object of the `Hex` class or any of its subclasses.
`String` and Hex` types belongs to two different hierarchies and those are not comparable with Jest `expect().toEqual()`.

The code below build the `expected` variable as an instance of the `Hex` class parsing the string `configData.TESTING_CONTRACT_BYTECODE` if its content is hexadecimal. This variable is comparable with `actual` of `Hex` type.

```typescript
describe('AccountsModule solo tests', () => {
    const thorClient = ThorClient.at(THOR_SOLO_URL);

    test(
        'ok <- contract address',
        async () => {
            const expected = Hex.of(configData.TESTING_CONTRACT_BYTECODE);
            const actual = await retryOperation(async () => {
                return await thorClient.accounts.getBytecode(
                    Address.of(CONTRACT_ADDRESS)
                );
            });
            expect(actual).toEqual(expected);
        },
        TIMEOUT
    );
});

```

Fixes #1982

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `yarn test:unit`
- [x] `yarn test:solo`

**Test Configuration**:
* Node.js Version: v24.0.0
* Yarn Version: 1.22.22
