### PR TITLE
Fix eth_call return value when Tx reverts

### DIFF
--- a/apps/sdk-hardhat-integration/contracts/RevertCustom.sol
+++ b/apps/sdk-hardhat-integration/contracts/RevertCustom.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.20;
+
+/**
+ * A simple contract that reverts with a custom error
+ */
+contract RevertCustom {
+
+    error CustomError(string message);
+
+    /*
+     * Revert with a custom error
+     * @return The error message
+     */
+    function revertWithCustomError(string memory errorMessage) public pure {
+        revert CustomError(errorMessage);
+    }
+}

--- a/apps/sdk-hardhat-integration/hardhat.config.ts
+++ b/apps/sdk-hardhat-integration/hardhat.config.ts
@@ -63,7 +63,7 @@ const config: HardhatUserConfig = {
                 initialIndex: 0,
                 passphrase: 'vechainthor'
             },
-            debug: true,
+            debug: false,
             gasPayer: undefined,
             gas: 'auto',
             gasPrice: 'auto',
@@ -132,9 +132,14 @@ const config: HardhatUserConfig = {
         vechain_solo: {
             // Thor solo network
             url: 'http://127.0.0.1:8669',
-            accounts: [
-                '7f9290cc44c5fd2b95fe21d6ad6fe5fa9c177e1cd6f3b4c96a97b13e09eaa158'
-            ],
+            accounts: {
+                mnemonic:
+                    'denial kitchen pet squirrel other broom bar gas better priority spoil cross',
+                path: HDKey.VET_DERIVATION_PATH,
+                count: 11,
+                initialIndex: 0,
+                passphrase: 'vechainthor'
+            },
             debug: false,
             enableDelegation: false,
             gasPayer: undefined,

--- a/apps/sdk-hardhat-integration/package.json
+++ b/apps/sdk-hardhat-integration/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "compile": "npx hardhat compile",
     "test": "npx hardhat test --network vechain_testnet",
+    "test:solo": "npx hardhat test --network vechain_solo",
     "deploy-solo": "npx hardhat run scripts/deploy.ts --network vechain_solo",
     "deploy-testnet": "npx hardhat run scripts/deploy.ts --network vechain_testnet",
     "deploy-erc20": "npx hardhat run scripts/erc20/deploy.ts --network vechain_testnet",

--- a/apps/sdk-hardhat-integration/test/check-revert-custom.solo.test.ts
+++ b/apps/sdk-hardhat-integration/test/check-revert-custom.solo.test.ts
@@ -1,0 +1,25 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+
+/**
+ * Tests for custom revert error
+ *
+ * @group integration/hardhat-plugin
+ */
+describe('Custom revert error', () => {
+
+    /**
+     * Test suite for revert with custom error
+     */
+    it('Should revert with custom error', async function () {
+        this.timeout(20000);
+        const revertCustomContract = await ethers.getContractFactory('RevertCustom');   
+        const contract = await revertCustomContract.deploy();
+        const contractInfo = await contract.waitForDeployment();
+        expect(contractInfo).to.not.equal(undefined);
+        await expect(
+            contract.revertWithCustomError('Custom error message')
+        ).to.be.revertedWithCustomError(contract, 'CustomError').withArgs('Custom error message');
+    });
+
+});

--- a/packages/errors/src/available-errors/provider/provider.ts
+++ b/packages/errors/src/available-errors/provider/provider.ts
@@ -160,6 +160,29 @@ class JSONRPCMethodNotImplemented extends JSONRPCProviderError {
     }
 }
 
+/**
+ * Revert error.
+ *
+ * WHEN TO USE:
+ * * When a Transaction is reverted.
+ */
+class JSONRPCTransactionRevertError extends Error {
+    code: number;
+    data?: string;
+    message: string;
+
+    constructor(message: string, data?: string) {
+        super(message || 'execution reverted');
+        this.message = message;
+        this.name = 'JSONRPCTransactionRevertError';
+        this.code = -32000;
+        this.data = data;
+
+        // Needed to make instanceof work when transpiled
+        Object.setPrototypeOf(this, new.target.prototype);
+    }
+}
+
 export {
     JSONRPCInternalError,
     JSONRPCInvalidParams,
@@ -170,5 +193,6 @@ export {
     JSONRPCProviderError,
     JSONRPCServerError,
     ProviderMethodError,
-    JSONRPCInvalidDefaultBlock
+    JSONRPCInvalidDefaultBlock,
+    JSONRPCTransactionRevertError
 };

--- a/packages/errors/tests/available-errors/rpc-proxy.unit.test.ts
+++ b/packages/errors/tests/available-errors/rpc-proxy.unit.test.ts
@@ -3,6 +3,7 @@ import {
     InvalidCommandLineArguments,
     InvalidConfigurationFile,
     InvalidConfigurationFilePath,
+    JSONRPCTransactionRevertError,
     VechainSDKError
 } from '../../src';
 
@@ -64,5 +65,18 @@ describe('Error package Available errors test - RPC Proxy', () => {
                 );
             }).toThrowError(VechainSDKError);
         });
+    });
+
+    test('JSONRPCTransactionRevertError', () => {
+        expect(() => {
+            throw new JSONRPCTransactionRevertError('message', 'data');
+        }).toThrowError(Error);
+
+        expect(() => {
+            throw new JSONRPCTransactionRevertError(
+                undefined as unknown as string,
+                undefined as unknown as string
+            );
+        }).toThrowError(Error);
     });
 });

--- a/packages/network/src/provider/providers/hardhat-provider/hardhat-provider.ts
+++ b/packages/network/src/provider/providers/hardhat-provider/hardhat-provider.ts
@@ -1,5 +1,6 @@
 import {
     JSONRPCInternalError,
+    JSONRPCTransactionRevertError,
     stringifyData,
     VechainSDKError
 } from '@vechain/sdk-errors';
@@ -184,16 +185,12 @@ class HardhatVeChainProvider extends VeChainProvider {
                 );
             }
 
+            // eth_call transaction revert error already in correct format
+            if (error instanceof JSONRPCTransactionRevertError) {
+                throw error;
+            }
+
             if (error instanceof VechainSDKError) {
-                // Throw the error
-                // eth_call is a special case, @nomiclabs/truffle-contract uses this error to revert the transaction
-                // @NOTE: Review whether makes sense to handle this case in a different way (error message per RPC method?)
-                if (args.method === 'eth_call') {
-                    throw this.buildHardhatErrorFunctionCallback(
-                        'revert',
-                        error
-                    );
-                }
                 throw this.buildHardhatErrorFunctionCallback(
                     `Error on request ${args.method}: ${error.innerError}`,
                     error

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_call/eth_call.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_call/eth_call.ts
@@ -1,6 +1,7 @@
 import {
     JSONRPCInternalError,
     JSONRPCInvalidParams,
+    JSONRPCTransactionRevertError,
     stringifyData
 } from '@vechain/sdk-errors';
 import {
@@ -65,20 +66,18 @@ const ethCall = async (
         );
 
         if (simulatedTx[0].reverted) {
-            throw new JSONRPCInternalError(
-                'eth_call()',
-                'Method "eth_call" failed when simulating the transaction.',
-                {
-                    params: stringifyData(params),
-                    innerError: simulatedTx[0].vmError
-                }
+            throw new JSONRPCTransactionRevertError(
+                simulatedTx[0].vmError,
+                simulatedTx[0].data
             );
         }
-
         // Return simulated transaction data
         return simulatedTx[0].data;
     } catch (e) {
         if (e instanceof JSONRPCInternalError) {
+            throw e;
+        }
+        if (e instanceof JSONRPCTransactionRevertError) {
             throw e;
         }
         throw new JSONRPCInternalError(


### PR DESCRIPTION
# Description

Fixes `eth_call` return value when transaction reverts and ensures that this return value propagates through the Vechain & Hardhat providers, so that Chai matchers can decode revert error data.

Fixes #2297 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] local solo tests

**Test Configuration**:
* Node.js Version: 18.18.0

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code