### PR TITLE
chore: use Revision type instead of string + fix CI to avoid failures as per #2306

### DIFF
--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_call/eth_call.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_call/eth_call.ts
@@ -55,7 +55,7 @@ const ethCall = async (
                 } satisfies SimulateTransactionClause
             ],
             {
-                revision: DefaultBlockToRevision(block).toString(),
+                revision: DefaultBlockToRevision(block),
                 gas:
                     inputOptions.gas !== undefined
                         ? parseInt(inputOptions.gas, 16)

--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_estimateGas/eth_estimateGas.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_estimateGas/eth_estimateGas.ts
@@ -61,7 +61,7 @@ const ethEstimateGas = async (
             ],
             inputOptions.from,
             {
-                revision: revision.toString()
+                revision: revision
             }
         );
 

--- a/packages/network/src/signer/signers/types.d.ts
+++ b/packages/network/src/signer/signers/types.d.ts
@@ -1,4 +1,4 @@
-import { type TransactionClause } from '@vechain/sdk-core';
+import { type Revision, type TransactionClause } from '@vechain/sdk-core';
 import type {
     TypedDataDomain as viemTypedDataDomain,
     TypedDataParameter as viemTypedDataParameter
@@ -339,7 +339,7 @@ interface VeChainSigner {
      */
     call: (
         transactionToEvaluate: TransactionRequestInput,
-        revision?: string
+        revision?: Revision
     ) => Promise<string>;
 
     /**

--- a/packages/network/src/signer/signers/vechain-abstract-signer/vechain-abstract-signer.ts
+++ b/packages/network/src/signer/signers/vechain-abstract-signer/vechain-abstract-signer.ts
@@ -5,6 +5,7 @@ import {
     Hex,
     HexUInt,
     Keccak256,
+    Revision,
     Txt,
     type TransactionBody,
     type TransactionClause
@@ -251,7 +252,7 @@ abstract class VeChainAbstractSigner implements VeChainSigner {
      */
     async call(
         transactionToEvaluate: TransactionRequestInput,
-        revision?: string
+        revision?: Revision
     ): Promise<string> {
         // 1 - Get the thor client
         if ((this.provider as AvailableVeChainProviders) === undefined) {

--- a/packages/network/src/thor-client/transactions/transactions-module.ts
+++ b/packages/network/src/thor-client/transactions/transactions-module.ts
@@ -695,7 +695,7 @@ class TransactionsModule {
         if (
             revision !== undefined &&
             revision !== null &&
-            !Revision.isValid(revision)
+            !Revision.isValid(revision.toString())
         ) {
             throw new InvalidDataType(
                 'TransactionsModule.simulateTransaction()',
@@ -706,9 +706,9 @@ class TransactionsModule {
 
         return (await this.blocksModule.httpClient.http(
             HttpMethod.POST,
-            thorest.accounts.post.SIMULATE_TRANSACTION(revision),
+            thorest.accounts.post.SIMULATE_TRANSACTION(revision?.toString()),
             {
-                query: buildQuery({ revision }),
+                query: buildQuery({ revision: revision?.toString() }),
                 body: {
                     clauses: await this.resolveNamesInClauses(
                         clauses.map((clause) => {

--- a/packages/network/src/thor-client/transactions/types.d.ts
+++ b/packages/network/src/thor-client/transactions/types.d.ts
@@ -1,4 +1,8 @@
-import type { TransactionBody, TransactionClause } from '@vechain/sdk-core';
+import type {
+    Revision,
+    TransactionBody,
+    TransactionClause
+} from '@vechain/sdk-core';
 import type { Output } from '../blocks';
 import { type Transfer } from '../logs';
 
@@ -135,7 +139,7 @@ interface SimulateTransactionOptions {
     /**
      * The block number or block ID of which the transaction simulation is based on
      */
-    revision?: string;
+    revision?: Revision;
     /**
      * The offered gas for the transaction simulation
      */


### PR DESCRIPTION

# Description

Use Revision type and cast to string only for HTTP related ops
ported fix for 2306 to avoid CI failures

Fixes #2289 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit
- [x] Solo

**Test Configuration**:
* Node.js Version: 20
* Yarn Version: 1.22

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code