### PR TITLE
Increase maxFeePerGas estimate

### DIFF
--- a/packages/network/src/provider/utils/rpc-mapper/methods/eth_estimateGas/eth_estimateGas.ts
+++ b/packages/network/src/provider/utils/rpc-mapper/methods/eth_estimateGas/eth_estimateGas.ts
@@ -80,7 +80,7 @@ const ethEstimateGas = async (
                         } satisfies SimulateTransactionClause
                     ],
                     {
-                        revision: revision.toString(),
+                        revision: revision,
                         caller: inputOptions.from
                     }
                 );

--- a/packages/network/src/thor-client/gas/gas-module.ts
+++ b/packages/network/src/thor-client/gas/gas-module.ts
@@ -7,7 +7,7 @@ import {
 } from './types';
 import { InvalidDataType } from '@vechain/sdk-errors';
 import { HttpMethod, type HttpClient } from '../../http';
-import { Revision } from '@vechain/sdk-core';
+import { HexUInt, Revision } from '@vechain/sdk-core';
 import { thorest } from '../../utils';
 import { type SimulateTransactionClause } from '../transactions/types';
 
@@ -173,6 +173,26 @@ class GasModule {
         }
 
         return response as FeeHistoryResponse;
+    }
+
+    /**
+     * Returns the base fee per gas of the next block.
+     * @returns The base fee per gas of the next block.
+     */
+    public async getNextBlockBaseFeePerGas(): Promise<bigint | null> {
+        const options: FeeHistoryOptions = {
+            blockCount: 1,
+            newestBlock: 'next'
+        };
+        const feeHistory = await this.getFeeHistory(options);
+        if (
+            feeHistory.baseFeePerGas === null ||
+            feeHistory.baseFeePerGas === undefined ||
+            feeHistory.baseFeePerGas.length === 0
+        ) {
+            return null;
+        }
+        return HexUInt.of(feeHistory.baseFeePerGas[0]).bi;
     }
 }
 


### PR DESCRIPTION
# Description

Increases the maxFeePerGas estimate when none is provider by the user.
- baseFeePerGas is now taken from next block (rather than best block)
- 1.12 (+12%) multiplier added to allow for approx +3 blocks headroom in increasing price market

Fixes #2343

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Local solo tests
- [x] Local unit tests


# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to retrieve the base fee per gas for the next block.
* **Improvements**
  * Updated gas fee calculations to use the next block's base fee and a refined formula for determining max fee per gas.
* **Tests**
  * Adjusted test cases to reflect changes in gas fee calculations and base fee retrieval, ensuring accurate validation with new logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->