### PR TITLE
Fix solo tests, add detect open handles

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -54,7 +54,7 @@
     "test:clients": "rm -rf ./coverageClients && jest --coverage --coverageDirectory=coverageClients --group=integration/clients",
     "test:clients:solo": "(yarn start-thor-solo && yarn seed-thor-solo && yarn test:clients && yarn stop-thor-solo) || yarn stop-thor-solo",
     "test:browser": "rm -rf ./coverage && jest --coverage --coverageDirectory=coverage --group=integration --group=unit --config ./jest.config.browser.js",
-    "test": "rm -rf ./coverage && jest --coverage --coverageDirectory=coverage --group=integration --group=unit --group=solo",
+    "test": "rm -rf ./coverage && jest --detectOpenHandles --coverage --coverageDirectory=coverage --group=integration --group=unit --group=solo",
     "test:group:solo": "rm -rf ./coverage && jest --coverage --coverageDirectory=coverage --group=solo",
     "test:solo": "(yarn start-thor-solo && yarn seed-thor-solo && yarn test:group:solo && yarn stop-thor-solo) || yarn stop-thor-solo",
     "test:browser:solo": "(yarn start-thor-solo && yarn test:browser && yarn stop-thor-solo) || yarn stop-thor-solo"

--- a/packages/sdk/src/thor/thor-client/ThorClient.ts
+++ b/packages/sdk/src/thor/thor-client/ThorClient.ts
@@ -13,7 +13,7 @@ class ThorClient {
      */
     public readonly accounts: AccountsModule;
 
-    /**gas instance */
+    /** gas instance */
     public readonly gas: GasModule;
 
     /**

--- a/packages/sdk/src/thor/thorest/accounts/response/ExecuteCodesResponse.ts
+++ b/packages/sdk/src/thor/thorest/accounts/response/ExecuteCodesResponse.ts
@@ -7,6 +7,7 @@ import {
     type ExecuteCodeResponseJSON,
     type ExecuteCodesResponseJSON
 } from '@thor/thorest/accounts/json';
+import { log } from '@common/logging';
 
 /**
  * Full-Qualified Path
@@ -107,18 +108,17 @@ class ExecuteCodeResponse {
  *
  * Represents a collection of execute code responses.
  */
-class ExecuteCodesResponse extends Array<ExecuteCodeResponse> {
+class ExecuteCodesResponse {
+    readonly items: ExecuteCodeResponse[];
     /**
      * Constructs a new instance of the class by parsing the provided JSON array.
      *
      * @param {ExecuteCodesResponseJSON} json - The JSON array containing execute code response data.
      */
     constructor(json: ExecuteCodesResponseJSON) {
-        super(
-            ...json.map(
-                (json: ExecuteCodeResponseJSON): ExecuteCodeResponse =>
-                    new ExecuteCodeResponse(json)
-            )
+        this.items = json.map(
+            (json: ExecuteCodeResponseJSON): ExecuteCodeResponse =>
+                new ExecuteCodeResponse(json)
         );
     }
 }

--- a/packages/sdk/src/viem/clients/Contract.ts
+++ b/packages/sdk/src/viem/clients/Contract.ts
@@ -9,7 +9,7 @@ import { type PublicClient, type WalletClient } from '@viem/clients';
 import { type ExecuteCodesRequestJSON } from '@thor/thorest/json';
 import { type SubscriptionEventResponse } from '@thor/thorest/subscriptions/response';
 import { type ExecuteCodesResponse } from '@thor/thorest/accounts/response';
-import { DecodedEventLog } from '@thor/thor-client/model/logs/DecodedEventLog';
+import { type DecodedEventLog } from '@thor/thor-client/model/logs/DecodedEventLog';
 
 // Type alias for hex-convertible values
 type HexConvertible = string | number | bigint;
@@ -227,11 +227,11 @@ function getContract<const TAbi extends Abi>({
                     // Call the contract
                     const response = await publicClient.call(request);
 
-                    if (response.length === 0) {
+                    if (response.items.length === 0) {
                         throw new Error('No response from contract call');
                     }
 
-                    const result = response[0].data;
+                    const result = response.items[0].data;
 
                     // Decode the result
                     if (abiItem.outputs != null && abiItem.outputs.length > 0) {

--- a/packages/sdk/tests/thor/thorest/accounts/InspectClauses.solo.test.ts
+++ b/packages/sdk/tests/thor/thorest/accounts/InspectClauses.solo.test.ts
@@ -41,12 +41,12 @@ describe('InspectClauses solo tests', () => {
                 FetchHttpClient.at(new URL(ThorNetworks.SOLONET))
             )
         ).response;
-        expect(response.length).toBe(1);
-        expect(response[0].data.toString()).toBe(
+        expect(response.items.length).toBe(1);
+        expect(response.items[0].data.toString()).toBe(
             '0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001d6275696c74696e3a20696e73756666696369656e742062616c616e6365000000'
         );
-        expect(response[0].gasUsed).toBe(1071n);
-        expect(response[0].reverted).toBe(true);
-        expect(response[0].vmError).toBe('execution reverted');
+        expect(response.items[0].gasUsed).toBe(1071n);
+        expect(response.items[0].reverted).toBe(true);
+        expect(response.items[0].vmError).toBe('execution reverted');
     });
 });

--- a/packages/sdk/tests/thor/thorest/accounts/InspectClauses.unit.test.ts
+++ b/packages/sdk/tests/thor/thorest/accounts/InspectClauses.unit.test.ts
@@ -87,25 +87,27 @@ describe('InspectClauses unit tests', () => {
         ];
 
         // Execute the test
-        const response = await InspectClauses.of(request).askTo(
-            mockHttpClient<ExecuteCodeResponseJSON[]>(mockResponse, 'post')
-        );
+        const response = (
+            await InspectClauses.of(request).askTo(
+                mockHttpClient<ExecuteCodeResponseJSON[]>(mockResponse, 'post')
+            )
+        ).response;
 
         // Verify the response
-        expect(response.response).toBeInstanceOf(Array);
-        expect(response.response.length).toBe(mockResponse.length);
-        expect(response.response[0].data.toString()).toBe(mockResponse[0].data);
-        expect(response.response[0].events[0].address.toString()).toBe(
+        expect(response.items).toBeInstanceOf(Array);
+        expect(response.items.length).toBe(mockResponse.length);
+        expect(response.items[0].data.toString()).toBe(mockResponse[0].data);
+        expect(response.items[0].events[0].address.toString()).toBe(
             mockResponse[0].events[0].address
         );
-        expect(response.response[0].gasUsed.valueOf()).toBe(
+        expect(response.items[0].gasUsed.valueOf()).toBe(
             BigInt(mockResponse[0].gasUsed)
         );
-        expect(response.response[0].reverted).toBe(mockResponse[0].reverted);
-        expect(response.response[0].vmError).toBe(mockResponse[0].vmError);
+        expect(response.items[0].reverted).toBe(mockResponse[0].reverted);
+        expect(response.items[0].vmError).toBe(mockResponse[0].vmError);
 
         // Verify specific aspects of the response
-        const outputs = response.response;
+        const outputs = response.items;
 
         // First clause (token transfer)
         expect(outputs[0].reverted).toBe(false);
@@ -157,12 +159,14 @@ describe('InspectClauses unit tests', () => {
         ];
 
         // Execute the test
-        const response = await InspectClauses.of(request).askTo(
-            mockHttpClient<ExecuteCodeResponseJSON[]>(mockResponse, 'post')
-        );
+        const response = (
+            await InspectClauses.of(request).askTo(
+                mockHttpClient<ExecuteCodeResponseJSON[]>(mockResponse, 'post')
+            )
+        ).response;
 
         // Verify the response
-        const output = response.response[0];
+        const output = response.items[0];
         expect(output.reverted).toBe(true);
         expect(output.vmError).toBe('invalid opcode 0x12');
         expect(output.events).toHaveLength(0);
@@ -185,8 +189,8 @@ describe('InspectClauses unit tests', () => {
         );
 
         // Verify the response
-        expect(response.response).toBeInstanceOf(Array);
-        expect(response.response).toHaveLength(0);
+        expect(response.response.items).toBeInstanceOf(Array);
+        expect(response.response.items).toHaveLength(0);
     });
 
     test('should handle out of gas scenario', async () => {
@@ -218,12 +222,14 @@ describe('InspectClauses unit tests', () => {
         ];
 
         // Execute the test
-        const response = await InspectClauses.of(request).askTo(
-            mockHttpClient<ExecuteCodeResponseJSON[]>(mockResponse, 'post')
-        );
+        const response = (
+            await InspectClauses.of(request).askTo(
+                mockHttpClient<ExecuteCodeResponseJSON[]>(mockResponse, 'post')
+            )
+        ).response;
 
         // Verify the response
-        const output = response.response[0];
+        const output = response.items[0];
         expect(output.reverted).toBe(true);
         expect(output.vmError).toBe('out of gas');
         expect(output.gasUsed.valueOf()).toBe(BigInt(1));

--- a/packages/sdk/tests/viem/clients/publicClient/contracts.solo.test.ts
+++ b/packages/sdk/tests/viem/clients/publicClient/contracts.solo.test.ts
@@ -64,11 +64,11 @@ describe('PublicClient - Contract/Call Methods', () => {
             const result = await publicClient.call(vthoBalanceCall);
 
             expect(result).toBeDefined();
-            expect(Array.isArray(result)).toBe(true);
-            expect(result.length).toBeGreaterThan(0);
+            expect(Array.isArray(result.items)).toBe(true);
+            expect(result.items.length).toBeGreaterThan(0);
 
             // Check first result
-            const firstResult = result[0];
+            const firstResult = result.items[0];
             expect(firstResult).toHaveProperty('data');
             expect(firstResult).toHaveProperty('gasUsed');
             expect(firstResult).toHaveProperty('reverted');
@@ -87,11 +87,11 @@ describe('PublicClient - Contract/Call Methods', () => {
             const result = await publicClient.call(multiClauseCall);
 
             expect(result).toBeDefined();
-            expect(Array.isArray(result)).toBe(true);
-            expect(result.length).toBe(2); // Should match number of clauses
+            expect(Array.isArray(result.items)).toBe(true);
+            expect(result.items.length).toBe(2); // Should match number of clauses
 
             // Check both results
-            result.forEach((clauseResult: any, index: number) => {
+            result.items.forEach((clauseResult: any, index: number) => {
                 expect(clauseResult).toHaveProperty('data');
                 expect(clauseResult).toHaveProperty('gasUsed');
                 expect(clauseResult).toHaveProperty('reverted');
@@ -111,10 +111,10 @@ describe('PublicClient - Contract/Call Methods', () => {
             const result = await publicClient.call(transferCall);
 
             expect(result).toBeDefined();
-            expect(Array.isArray(result)).toBe(true);
-            expect(result.length).toBeGreaterThan(0);
+            expect(Array.isArray(result.items)).toBe(true);
+            expect(result.items.length).toBeGreaterThan(0);
 
-            const firstResult = result[0];
+            const firstResult = result.items[0];
             expect(firstResult).toHaveProperty('data');
             expect(firstResult).toHaveProperty('gasUsed');
             expect(firstResult).toHaveProperty('reverted');
@@ -136,11 +136,11 @@ describe('PublicClient - Contract/Call Methods', () => {
             const result = await publicClient.simulateCalls(vthoBalanceCall);
 
             expect(result).toBeDefined();
-            expect(Array.isArray(result)).toBe(true);
-            expect(result.length).toBeGreaterThan(0);
+            expect(Array.isArray(result.items)).toBe(true);
+            expect(result.items.length).toBeGreaterThan(0);
 
             // Check first result
-            const firstResult = result[0];
+            const firstResult = result.items[0];
             expect(firstResult).toHaveProperty('data');
             expect(firstResult).toHaveProperty('gasUsed');
             expect(firstResult).toHaveProperty('reverted');
@@ -159,11 +159,11 @@ describe('PublicClient - Contract/Call Methods', () => {
             const result = await publicClient.simulateCalls(multiClauseCall);
 
             expect(result).toBeDefined();
-            expect(Array.isArray(result)).toBe(true);
-            expect(result.length).toBe(2); // Should match number of clauses
+            expect(Array.isArray(result.items)).toBe(true);
+            expect(result.items.length).toBe(2); // Should match number of clauses
 
             // Check both results
-            result.forEach((clauseResult: any, index: number) => {
+            result.items.forEach((clauseResult: any, index: number) => {
                 expect(clauseResult).toHaveProperty('data');
                 expect(clauseResult).toHaveProperty('gasUsed');
                 expect(clauseResult).toHaveProperty('reverted');
@@ -186,13 +186,15 @@ describe('PublicClient - Contract/Call Methods', () => {
 
             expect(callResult).toBeDefined();
             expect(simulateResult).toBeDefined();
-            expect(callResult.length).toBe(simulateResult.length);
+            expect(callResult.items.length).toBe(simulateResult.items.length);
 
             // Results should be identical since both methods do the same thing in VeChain
-            expect(callResult[0].data.toString()).toBe(
-                simulateResult[0].data.toString()
+            expect(callResult.items[0].data.toString()).toBe(
+                simulateResult.items[0].data.toString()
             );
-            expect(callResult[0].reverted).toBe(simulateResult[0].reverted);
+            expect(callResult.items[0].reverted).toBe(
+                simulateResult.items[0].reverted
+            );
         });
     });
 
@@ -213,10 +215,10 @@ describe('PublicClient - Contract/Call Methods', () => {
             const result = await publicClient.call(invalidCall);
 
             expect(result).toBeDefined();
-            expect(Array.isArray(result)).toBe(true);
+            expect(Array.isArray(result.items)).toBe(true);
 
             // Call to zero address might revert or return empty data
-            const firstResult = result[0];
+            const firstResult = result.items[0];
             expect(firstResult).toHaveProperty('reverted');
 
             log.debug({
@@ -245,10 +247,10 @@ describe('PublicClient - Contract/Call Methods', () => {
             const result = await publicClient.call(invalidDataCall);
 
             expect(result).toBeDefined();
-            expect(Array.isArray(result)).toBe(true);
+            expect(Array.isArray(result.items)).toBe(true);
 
             // Invalid function call should typically revert
-            const firstResult = result[0];
+            const firstResult = result.items[0];
             expect(firstResult).toHaveProperty('reverted');
 
             log.debug({
@@ -277,10 +279,10 @@ describe('PublicClient - Contract/Call Methods', () => {
             const result = await publicClient.call(lowGasCall);
 
             expect(result).toBeDefined();
-            expect(Array.isArray(result)).toBe(true);
+            expect(Array.isArray(result.items)).toBe(true);
 
             // Low gas might cause revert or just use all available gas
-            const firstResult = result[0];
+            const firstResult = result.items[0];
             expect(firstResult).toHaveProperty('gasUsed');
 
             log.debug({

--- a/packages/sdk/tests/viem/clients/publicClient/fees.solo.test.ts
+++ b/packages/sdk/tests/viem/clients/publicClient/fees.solo.test.ts
@@ -236,24 +236,17 @@ describe('PublicClient - Fee Estimation Methods', () => {
     describe('estimateMaxPriorityFeePerGas', () => {
         test('should estimate max priority fee per gas', async () => {
             const priorityFeeResponse =
-                await publicClient.estimateMaxPriorityFeePerGas();
+                await publicClient.suggestPriorityFeeRequest();
 
             expect(priorityFeeResponse).toBeDefined();
-            expect(typeof priorityFeeResponse).toBe('object');
-            expect(priorityFeeResponse.maxPriorityFeePerGas).toBeDefined();
-            expect(typeof priorityFeeResponse.maxPriorityFeePerGas).toBe(
-                'bigint'
-            );
-            expect(
-                priorityFeeResponse.maxPriorityFeePerGas
-            ).toBeGreaterThanOrEqual(0n);
+            expect(typeof priorityFeeResponse).toBe('bigint');
+            expect(priorityFeeResponse).toBeDefined();
+            expect(priorityFeeResponse).toBeGreaterThanOrEqual(0n);
 
             log.debug({
-                message:
-                    'Priority Fee: ' +
-                    priorityFeeResponse.maxPriorityFeePerGas.toString(),
+                message: 'Priority Fee: ' + priorityFeeResponse.toString(),
                 context: {
-                    data: priorityFeeResponse.maxPriorityFeePerGas.toString()
+                    data: priorityFeeResponse.toString()
                 }
             });
         }, 10000);


### PR DESCRIPTION
# Description

- Fixes the solo tests
- Change to FetchHttpClient so that abort signal can be used in a `finally` --> this closes approx 13 jest warnings about open handles


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] local unit tests
- [x] local solo tests

**Test Configuration**:
* Node.js Version: v22
* Yarn Version: v1

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code