### PR TITLE
feat: added signed encode/decode

### DIFF
--- a/packages/sdk/src/thor/thor-client/model/transactions/Clause.ts
+++ b/packages/sdk/src/thor/thor-client/model/transactions/Clause.ts
@@ -1,13 +1,14 @@
-import { type Address, type Hex } from '@common/vcdm';
-import { type ClauseData } from '@thor/thorest';
+import { Address, Hex, HexUInt, Quantity } from '@common/vcdm';
+import { type ClauseJSON } from '@thor/thorest/json';
+import { IllegalArgumentError } from '@common/errors';
 
 /**
  * Full-Qualified Path
  */
-const FQP = 'packages/sdk/src/thor/thor-client/model/transactions/Clause.ts!';
+const FQP = 'packages/sdk/src/thor/thorest/model/Clause.ts!';
 
 /**
- * Clause for a transaction.
+ * [Clause](http://localhost:8669/doc/stoplight-ui/#/schemas/Clause)
  */
 class Clause {
     /**
@@ -27,11 +28,15 @@ class Clause {
 
     /**
      * Optional comment for the clause, helpful for displaying what the clause is doing.
+     *
+     * Not serialized in {@link ClauseJSON}.
      */
     readonly comment: string | null;
 
     /**
      * Optional ABI for the contract method invocation.
+     *
+     * Not serialized in {@link ClauseJSON}.
      */
     readonly abi: string | null;
 
@@ -69,14 +74,38 @@ class Clause {
      * @return {Clause} A new Clause instance created using the data extracted from the provided ClauseJSON object.
      * @throws {IllegalArgumentError} If the provided JSON object contains invalid data or couldn't be properly parsed.
      */
-    public static of(clauseData: ClauseData): Clause {
-        return new Clause(
-            clauseData.to,
-            clauseData.value,
-            clauseData.data,
-            null,
-            null
-        );
+    public static of(json: ClauseJSON): Clause {
+        try {
+            return new Clause(
+                json.to !== null ? Address.of(json.to) : null,
+                HexUInt.of(json.value).bi,
+                json.data !== undefined ? HexUInt.of(json.data) : null,
+                null,
+                null
+            );
+        } catch (error) {
+            throw new IllegalArgumentError(
+                `${FQP}of(json ClauseJSON)`,
+                'Bad parse',
+                { json },
+                error instanceof Error ? error : undefined
+            );
+        }
+    }
+
+    /**
+     * Converts the current instance of the class into a ClauseJSON representation.
+     *
+     * No input data is expressed as `0x`.
+     *
+     * @return {ClauseJSON} The JSON object representing the current instance.
+     */
+    toJSON(): ClauseJSON {
+        return {
+            to: this.to !== null ? this.to.toString() : null,
+            value: Quantity.of(this.value).toString(),
+            data: this.data !== null ? this.data.toString() : Hex.PREFIX
+        } satisfies ClauseJSON;
     }
 }
 

--- a/packages/sdk/src/thor/thor-client/model/transactions/SignedTransactionRequest.ts
+++ b/packages/sdk/src/thor/thor-client/model/transactions/SignedTransactionRequest.ts
@@ -3,7 +3,8 @@ import {
     type TransactionRequestParam
 } from './TransactionRequest';
 import type { Address } from '@common';
-
+import { HexUInt } from '@common';
+import { type SignedTransactionRequestJSON } from '@thor/thorest/json';
 /**
  * Represents the parameters required for a signed transaction request.
  * Extends the base `TransactionRequestParam` interface to include fields specific to signed transactions.
@@ -75,6 +76,20 @@ class SignedTransactionRequest
      */
     public isSigned(): boolean {
         return true;
+    }
+
+    /**
+     * Converts the SignedTransactionRequest object into its JSON representation.
+     *
+     * @return {SignedTransactionRequestJSON} The JSON representation of the SignedTransactionRequest object.
+     */
+    public toJSON(): SignedTransactionRequestJSON {
+        return {
+            ...super.toJSON(),
+            origin: this.origin.toString(),
+            originSignature: HexUInt.of(this.originSignature).toString(),
+            signature: HexUInt.of(this.signature).toString()
+        } satisfies SignedTransactionRequestJSON;
     }
 }
 

--- a/packages/sdk/src/thor/thor-client/model/transactions/SponsoredTransactionRequest.ts
+++ b/packages/sdk/src/thor/thor-client/model/transactions/SponsoredTransactionRequest.ts
@@ -1,8 +1,9 @@
-import { type Address } from '@common';
+import { type Address, HexUInt } from '@common';
 import {
     SignedTransactionRequest,
     type SignedTransactionRequestParam
-} from './SignedTransactionRequest';
+} from '../../../../../dist/thor';
+import { type SponsoredTransactionRequestJSON } from '@thor/thorest/json';
 
 /**
  * Represents the parameters required for a sponsored transaction request.
@@ -51,6 +52,19 @@ class SponsoredTransactionRequest
         super(params);
         this.gasPayer = params.gasPayer;
         this.gasPayerSignature = new Uint8Array(params.gasPayerSignature);
+    }
+
+    /**
+     * Converts the SponsoredTransactionRequest object into its JSON representation.
+     *
+     * @return {SponsoredTransactionRequestJSON} The JSON representation of the SponsoredTransactionRequest object.
+     */
+    toJSON(): SponsoredTransactionRequestJSON {
+        return {
+            ...super.toJSON(),
+            gasPayer: this.gasPayer.toString(),
+            gasPayerSignature: HexUInt.of(this.gasPayerSignature).toString()
+        } satisfies SponsoredTransactionRequestJSON;
     }
 }
 

--- a/packages/sdk/src/thor/thor-client/model/transactions/TransactionRequest.ts
+++ b/packages/sdk/src/thor/thor-client/model/transactions/TransactionRequest.ts
@@ -1,6 +1,6 @@
 import { type Clause } from './Clause';
 import { type Hex } from '@common';
-
+import { type TransactionRequestJSON } from '@thor/thorest/json';
 /**
  * Represents the parameters required to create a {@link TransactionRequest} instance.
  */
@@ -162,6 +162,25 @@ class TransactionRequest implements TransactionRequestParam {
      */
     public isSigned(): boolean {
         return false;
+    }
+
+    /**
+     * Converts the TransactionRequest object into a JSON representation.
+     *
+     * @return {TransactionRequestJSON} The JSON representation of the TransactionRequest object.
+     */
+    public toJSON(): TransactionRequestJSON {
+        return {
+            blockRef: this.blockRef.toString(),
+            chainTag: this.chainTag,
+            clauses: this.clauses.map((clause: Clause) => clause.toJSON()),
+            dependsOn: this.dependsOn?.toString() ?? null,
+            expiration: this.expiration,
+            gas: this.gas,
+            gasPriceCoef: this.gasPriceCoef,
+            nonce: this.nonce,
+            isIntendedToBeSponsored: this.isIntendedToBeSponsored ?? false
+        } satisfies TransactionRequestJSON;
     }
 
     /**

--- a/packages/sdk/src/thor/thorest/json/SignedTransactionRequestJSON.ts
+++ b/packages/sdk/src/thor/thorest/json/SignedTransactionRequestJSON.ts
@@ -1,0 +1,12 @@
+import { type TransactionRequestJSON } from '@thor/thorest/json/TransactionRequestJSON';
+
+/**
+ * Represents the content of a {@link SignedTransactionRequest} object in JSON format.
+ */
+interface SignedTransactionRequestJSON extends TransactionRequestJSON {
+    origin: string; // hex address
+    originSignature: string; // hex origin signature
+    signature: string; // hex signature
+}
+
+export { type SignedTransactionRequestJSON };

--- a/packages/sdk/src/thor/thorest/json/SponsoredTransactionRequestJSON.ts
+++ b/packages/sdk/src/thor/thorest/json/SponsoredTransactionRequestJSON.ts
@@ -1,0 +1,11 @@
+import { type SignedTransactionRequestJSON } from '@thor/thorest/json/SignedTransactionRequestJSON';
+
+/**
+ * Represents the content of a {@link SponsoredTransactionRequest} object in JSON format.
+ */
+interface SponsoredTransactionRequestJSON extends SignedTransactionRequestJSON {
+    gasPayer: string; // hex address
+    gasPayerSignature: string; // hex signature
+}
+
+export { type SponsoredTransactionRequestJSON };

--- a/packages/sdk/src/thor/thorest/json/TransactionRequestJSON.ts
+++ b/packages/sdk/src/thor/thorest/json/TransactionRequestJSON.ts
@@ -1,0 +1,18 @@
+import { type ClauseJSON } from '@thor/thorest/json/ClauseJSON';
+
+/**
+ * Represents the content of a {@link TransactionRequest} object in JSON format.
+ */
+interface TransactionRequestJSON {
+    blockRef: string;
+    chainTag: number;
+    clauses: ClauseJSON[];
+    dependsOn: string | null;
+    expiration: number;
+    gas: bigint;
+    gasPriceCoef: bigint;
+    nonce: number;
+    isIntendedToBeSponsored: boolean;
+}
+
+export { type TransactionRequestJSON };

--- a/packages/sdk/src/thor/thorest/json/index.ts
+++ b/packages/sdk/src/thor/thorest/json/index.ts
@@ -11,3 +11,6 @@ export * from '../debug/json';
 export * from '../node/json';
 export * from '../accounts/json';
 export * from '../logs/json';
+export * from './TransactionRequestJSON';
+export * from './SignedTransactionRequestJSON';
+export * from './SponsoredTransactionRequestJSON';

--- a/packages/sdk/src/thor/thorest/transactions/model/Transaction.ts
+++ b/packages/sdk/src/thor/thorest/transactions/model/Transaction.ts
@@ -224,7 +224,9 @@ class Transaction {
                     this.getTransactionHash(this.origin).bytes,
                     this.gasPayerSignature
                 );
-                return Address.ofPublicKey(gasPayerPublicKey);
+                const a = Address.ofPublicKey(gasPayerPublicKey);
+                console.log('E ' + a.toString());
+                return a;
             }
             throw new NoSuchElementError(
                 `${FQP}<Transaction>.gasPayer(): Address`,
@@ -336,10 +338,11 @@ class Transaction {
      */
     public get origin(): Address {
         if (this.senderSignature !== undefined) {
+            const hash = this.getTransactionHash().bytes;
             return Address.ofPublicKey(
                 // Get the origin public key.
                 Secp256k1.recover(
-                    this.getTransactionHash().bytes,
+                    hash,
                     // Get the (r, s) of ECDSA digital signature without gas payer params.
                     this.senderSignature
                 )

--- a/packages/sdk/tests/thor/signer/PrivateKeySigner.unit.test.ts
+++ b/packages/sdk/tests/thor/signer/PrivateKeySigner.unit.test.ts
@@ -15,7 +15,6 @@ import {
     TransactionRequest
 } from '@thor/thor-client/model/transactions';
 import { PrivateKeySigner, RLPCodecTransactionRequest } from '@thor/signer';
-import { newTransactionFromTransactionRequest } from './RLPCodec.unit.test';
 import * as nc_utils from '@noble/curves/abstract/utils';
 
 /**
@@ -30,18 +29,6 @@ describe('PrivateKeySigner', () => {
     );
     const mockHash = new Uint8Array(32).fill(2);
     const mockSignature = new Uint8Array(65).fill(3);
-
-    const mockSender = {
-        privateKey: HexUInt.of(
-            'ea5383ac1f9e625220039a4afac6a7f868bf1ad4f48ce3a1dd78bd214ee4ace5'
-        ).bytes
-    };
-
-    const mockGasPayer = {
-        privateKey: HexUInt.of(
-            '432f38bcf338c374523e83fdb2ebe1030aba63c7f1e81f7d76c5f53f4d42e766'
-        ).bytes
-    };
 
     // Common transaction request parameters
     const transactionParams = {
@@ -69,40 +56,13 @@ describe('PrivateKeySigner', () => {
 
         jest.spyOn(Secp256k1, 'sign').mockReturnValue(mockSignature);
 
-        jest.spyOn(
-            RLPCodecTransactionRequest,
-            'encodeTransactionRequest'
-        ).mockReturnValue(new Uint8Array(10).fill(4));
+        jest.spyOn(RLPCodecTransactionRequest, 'encode').mockReturnValue(
+            new Uint8Array(10).fill(4)
+        );
     });
 
     afterEach(() => {
         jest.restoreAllMocks();
-    });
-
-    describe('disponse method', () => {
-        test('ok <- clear the private key and set it to null', () => {
-            const privateKey = new Uint8Array(32).fill(1);
-            const signer = new PrivateKeySigner(privateKey);
-
-            signer.disponse();
-
-            // Attempt to sign to verify the private key is cleared
-            const txRequest = new TransactionRequest(transactionParams);
-            expect(() => signer.sign(txRequest)).toThrow(
-                InvalidPrivateKeyError
-            );
-        });
-
-        test('ok <- should be safe to call disponse multiple times', () => {
-            const signer = new PrivateKeySigner(validPrivateKey);
-
-            signer.disponse();
-            signer.disponse(); // Second call should not throw
-
-            expect(() => {
-                signer.disponse();
-            }).not.toThrow();
-        });
     });
 
     describe('constructor', () => {
@@ -153,21 +113,47 @@ describe('PrivateKeySigner', () => {
         });
     });
 
-    describe('sign method with TransactionRequest', () => {
-        test('ok <- sign a regular transaction request', () => {
+    describe('dispose method', () => {
+        test('ok <- clear the private key and set it to null', () => {
+            const privateKey = new Uint8Array(32).fill(1);
+            const signer = new PrivateKeySigner(privateKey);
+
+            signer.dispose();
+
+            // Attempt to sign to verify the private key is cleared
+            const txRequest = new TransactionRequest(transactionParams);
+            expect(() => signer.sign(txRequest)).toThrow(
+                InvalidPrivateKeyError
+            );
+        });
+
+        test('ok <- should be safe to call dispose multiple times', () => {
             const signer = new PrivateKeySigner(validPrivateKey);
+
+            signer.dispose();
+            signer.dispose(); // Second call should not throw
+
+            expect(() => {
+                signer.dispose();
+            }).not.toThrow();
+        });
+    });
+
+    describe('sign', () => {
+        test('ok <- sign a not-sponsored unsigned transaction request', () => {
+            const originSigner = new PrivateKeySigner(validPrivateKey);
             const txRequest = new TransactionRequest({
                 ...transactionParams,
                 isIntendedToBeSponsored: false
             });
 
-            const signedTx = signer.sign(txRequest);
+            const signedTx = originSigner.sign(txRequest);
 
             expect(signedTx).toBeInstanceOf(SignedTransactionRequest);
             // eslint-disable-next-line @typescript-eslint/unbound-method
-            expect(
-                RLPCodecTransactionRequest.encodeTransactionRequest
-            ).toHaveBeenCalledWith(txRequest);
+            expect(RLPCodecTransactionRequest.encode).toHaveBeenCalledWith(
+                txRequest
+            );
             // eslint-disable-next-line @typescript-eslint/unbound-method
             expect(Blake2b256.of).toHaveBeenCalled();
             // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -184,50 +170,41 @@ describe('PrivateKeySigner', () => {
             expect(signedTx.chainTag).toBe(txRequest.chainTag);
             expect(signedTx.clauses).toBe(txRequest.clauses);
             expect(signedTx.isIntendedToBeSponsored).toBe(false);
-        });
 
-        test('ok <- signature clones the origin signature', () => {
-            const txRequest = new TransactionRequest(transactionParams);
-            const sender = new PrivateKeySigner(mockSender.privateKey);
-            const signedTx = sender.sign(txRequest);
             expect(signedTx.originSignature).toEqual(signedTx.signature);
-
-            // Temporary until Transaction exists.
-            const expectedSignedTx = newTransactionFromTransactionRequest(
-                txRequest
-            ).sign(mockSender.privateKey);
-            expect(signedTx.signature).toEqual(expectedSignedTx.signature);
         });
 
-        test('ok <- sign a transaction request marked for sponsorship', () => {
-            const signer = new PrivateKeySigner(validPrivateKey);
+        test('ok <- sign a sponsored unsigned transaction request', () => {
+            const originSigner = new PrivateKeySigner(validPrivateKey);
             const txRequest = new TransactionRequest({
                 ...transactionParams,
                 isIntendedToBeSponsored: true
             });
 
-            const signedTx = signer.sign(txRequest);
+            const signedTx = originSigner.sign(txRequest);
 
             expect(signedTx).toBeInstanceOf(SignedTransactionRequest);
             expect(signedTx.isIntendedToBeSponsored).toBe(true);
+
+            expect(signedTx.originSignature).toEqual(signedTx.signature);
         });
 
-        test('err <- throw error if private key is voided before signing', () => {
-            const signer = new PrivateKeySigner(validPrivateKey);
+        test('err <- throw error if private key is disposed before signing', () => {
+            const originSigner = new PrivateKeySigner(validPrivateKey);
             const txRequest = new TransactionRequest(transactionParams);
 
-            signer.disponse();
+            originSigner.dispose();
 
-            expect(() => signer.sign(txRequest)).toThrow(
+            expect(() => originSigner.sign(txRequest)).toThrow(
                 InvalidPrivateKeyError
             );
         });
-    });
 
-    describe('sign method with SignedTransactionRequest (sponsoring)', () => {
-        test('ok <- sponsor a signed transaction request', () => {
-            const sender = new PrivateKeySigner(new Uint8Array(32).fill(5));
-            const gasPayer = new PrivateKeySigner(validPrivateKey);
+        test('ok <- sponsor a sponsored signed transaction request', () => {
+            const originSigner = new PrivateKeySigner(
+                new Uint8Array(32).fill(5)
+            );
+            const gasPayerSigner = new PrivateKeySigner(validPrivateKey);
 
             // Create a transaction request marked for sponsorship
             const txRequest = new TransactionRequest({
@@ -235,8 +212,8 @@ describe('PrivateKeySigner', () => {
                 isIntendedToBeSponsored: true
             });
 
-            // Sign it with the origin gasPayer
-            const signedTx = sender.sign(txRequest);
+            // Sign it with the origin gasPayerSigner
+            const signedTx = originSigner.sign(txRequest);
 
             // Mock the concatenated hash
             jest.spyOn(nc_utils, 'concatBytes').mockImplementation(
@@ -244,7 +221,7 @@ describe('PrivateKeySigner', () => {
             );
 
             // Sponsor the transaction
-            const sponsoredTx = gasPayer.sign(
+            const sponsoredTx = gasPayerSigner.sign(
                 signedTx
             ) as SponsoredTransactionRequest;
 
@@ -265,45 +242,17 @@ describe('PrivateKeySigner', () => {
                 signedTx.originSignature,
                 mockSignature
             );
-        });
 
-        test('ok <- signature combines origin and gas payer signatures', () => {
-            const txRequest = new TransactionRequest({
-                ...transactionParams,
-                isIntendedToBeSponsored: true
-            });
-            const sender = new PrivateKeySigner(mockSender.privateKey);
-            const signedTx = sender.sign(txRequest);
-            const gasPayer: PrivateKeySigner = new PrivateKeySigner(
-                mockGasPayer.privateKey
-            );
-            const sponsoredTx = gasPayer.sign(signedTx);
             expect(sponsoredTx.signature).toEqual(
                 nc_utils.concatBytes(
                     signedTx.signature,
-                    (sponsoredTx as SponsoredTransactionRequest)
-                        .gasPayerSignature
+                    sponsoredTx.gasPayerSignature
                 )
-            );
-
-            // Temporary until Transaction exists.
-            const expectedSignedTx = newTransactionFromTransactionRequest(
-                txRequest
-            ).signAsSender(mockSender.privateKey);
-            expect(sponsoredTx.originSignature).toEqual(
-                expectedSignedTx.signature
-            );
-            const expectedSponsoredTx = expectedSignedTx.signAsGasPayer(
-                sender.address,
-                mockGasPayer.privateKey
-            );
-            expect(sponsoredTx.signature).toEqual(
-                expectedSponsoredTx.signature
             );
         });
 
         test('err <- throw UnsupportedOperationError when sponsoring non-sponsored transaction', () => {
-            const signer = new PrivateKeySigner(validPrivateKey);
+            const gasPayerSigner = new PrivateKeySigner(validPrivateKey);
             const originSigner = new PrivateKeySigner(
                 new Uint8Array(32).fill(5)
             );
@@ -314,17 +263,17 @@ describe('PrivateKeySigner', () => {
                 isIntendedToBeSponsored: false
             });
 
-            // Sign it with the origin signer
+            // Sign it with the origin gasPayerSigner
             const signedTx = originSigner.sign(txRequest);
 
             // Attempt to sponsor the transaction
-            expect(() => signer.sign(signedTx)).toThrow(
+            expect(() => gasPayerSigner.sign(signedTx)).toThrow(
                 UnsupportedOperationError
             );
         });
 
         test('err <- throw InvalidPrivateKeyError if private key is voided before sponsoring', () => {
-            const signer = new PrivateKeySigner(validPrivateKey);
+            const gasPayerSigner = new PrivateKeySigner(validPrivateKey);
             const originSigner = new PrivateKeySigner(
                 new Uint8Array(32).fill(5)
             );
@@ -335,14 +284,16 @@ describe('PrivateKeySigner', () => {
                 isIntendedToBeSponsored: true
             });
 
-            // Sign it with the origin signer
+            // Sign it with the origin gasPayerSigner
             const signedTx = originSigner.sign(txRequest);
 
-            // Void the signer's private key
-            signer.disponse();
+            // Void the gasPayerSigner's private key
+            gasPayerSigner.dispose();
 
             // Attempt to sponsor the transaction
-            expect(() => signer.sign(signedTx)).toThrow(InvalidPrivateKeyError);
+            expect(() => gasPayerSigner.sign(signedTx)).toThrow(
+                InvalidPrivateKeyError
+            );
         });
     });
 });

--- a/packages/sdk/tests/thor/thor-client/transactions/SponsoredTransactionRequest.unit.test.ts
+++ b/packages/sdk/tests/thor/thor-client/transactions/SponsoredTransactionRequest.unit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect } from '@jest/globals';
-import { Address, BlockRef } from '@common';
+import { Address, BlockRef, HexUInt } from '@common';
 import {
+    Clause,
     SignedTransactionRequest,
     SponsoredTransactionRequest,
     type SponsoredTransactionRequestParam,
@@ -117,6 +118,210 @@ describe('SponsoredTransactionRequest', () => {
     describe('isSigned', () => {
         test('isSigned method should return true', () => {
             expect(sponsoredTxRequest.isSigned()).toBe(true);
+        });
+    });
+
+    describe('toJSON', () => {
+        test('ok <- should convert SponsoredTransactionRequest to JSON with all properties including gas payer info', () => {
+            const json = sponsoredTxRequest.toJSON();
+
+            // Verify all base TransactionRequest properties are included
+            expect(json.blockRef).toBe(mockParams.blockRef.toString());
+            expect(json.chainTag).toBe(mockParams.chainTag);
+            expect(json.clauses).toEqual([]);
+            expect(json.dependsOn).toBeNull();
+            expect(json.expiration).toBe(mockParams.expiration);
+            expect(json.gas).toBe(mockParams.gas);
+            expect(json.gasPriceCoef).toBe(mockParams.gasPriceCoef);
+            expect(json.nonce).toBe(mockParams.nonce);
+            expect(json.isIntendedToBeSponsored).toBe(
+                mockParams.isIntendedToBeSponsored
+            );
+
+            // Verify SignedTransactionRequest properties are included
+            expect(json.origin).toBe(mockParams.origin.toString());
+            expect(json.originSignature).toBe('0x0102030405');
+            expect(json.signature).toBe('0x060708090a');
+
+            // Verify SponsoredTransactionRequest specific properties
+            expect(json.gasPayer).toBe(mockParams.gasPayer.toString());
+            expect(json.gasPayerSignature).toBe('0x0b0c0d0e0f');
+        });
+
+        test('ok <- should convert SponsoredTransactionRequest to JSON with clauses', () => {
+            const clauseParams = {
+                ...mockParams,
+                clauses: [new Clause(mockOrigin, 1000n, null, null, null)]
+            };
+            const sponsoredRequestWithClause = new SponsoredTransactionRequest(
+                clauseParams
+            );
+
+            const json = sponsoredRequestWithClause.toJSON();
+
+            expect(json.clauses).toHaveLength(1);
+            expect(json.clauses[0]).toEqual(clauseParams.clauses[0].toJSON());
+        });
+
+        test('ok <- should convert SponsoredTransactionRequest to JSON with dependsOn value', () => {
+            const dependsOnValue = BlockRef.of(
+                '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890'
+            );
+            const paramsWithDependsOn = {
+                ...mockParams,
+                dependsOn: dependsOnValue
+            };
+            const sponsoredRequestWithDependsOn =
+                new SponsoredTransactionRequest(paramsWithDependsOn);
+
+            const json = sponsoredRequestWithDependsOn.toJSON();
+
+            expect(json.dependsOn).toBe(dependsOnValue.toString());
+        });
+
+        test('ok <- should properly convert Uint8Array gas payer signature to hex string', () => {
+            const largeGasPayerSignature = new Uint8Array([
+                255, 254, 253, 252, 251, 250, 249, 248
+            ]);
+
+            const paramsWithLargeGasPayerSignature = {
+                ...mockParams,
+                gasPayerSignature: largeGasPayerSignature
+            };
+            const sponsoredRequestWithLargeGasPayerSignature =
+                new SponsoredTransactionRequest(
+                    paramsWithLargeGasPayerSignature
+                );
+
+            const json = sponsoredRequestWithLargeGasPayerSignature.toJSON();
+
+            expect(json.gasPayerSignature).toEqual(
+                HexUInt.of(largeGasPayerSignature).toString()
+            );
+            expect(typeof json.gasPayerSignature).toBe('string');
+        });
+
+        test('ok <- should handle empty gas payer signature array', () => {
+            const emptyGasPayerSignatureParams = {
+                ...mockParams,
+                gasPayerSignature: new Uint8Array([])
+            };
+            const sponsoredRequestWithEmptyGasPayerSignature =
+                new SponsoredTransactionRequest(emptyGasPayerSignatureParams);
+
+            const json = sponsoredRequestWithEmptyGasPayerSignature.toJSON();
+
+            expect(json.gasPayerSignature).toBe('0x');
+        });
+
+        test('ok <- should handle single byte gas payer signature', () => {
+            const singleByteGasPayerSignatureParams = {
+                ...mockParams,
+                gasPayerSignature: new Uint8Array([200])
+            };
+            const sponsoredRequestWithSingleByteGasPayerSignature =
+                new SponsoredTransactionRequest(
+                    singleByteGasPayerSignatureParams
+                );
+
+            const json =
+                sponsoredRequestWithSingleByteGasPayerSignature.toJSON();
+
+            expect(json.gasPayerSignature).toBe('0xc8');
+        });
+
+        test('ok <- should handle all signature arrays with different values', () => {
+            const differentSignaturesParams = {
+                ...mockParams,
+                originSignature: new Uint8Array([10, 20, 30]),
+                signature: new Uint8Array([40, 50, 60]),
+                gasPayerSignature: new Uint8Array([70, 80, 90])
+            };
+            const sponsoredRequestWithDifferentSignatures =
+                new SponsoredTransactionRequest(differentSignaturesParams);
+
+            const json = sponsoredRequestWithDifferentSignatures.toJSON();
+
+            expect(json.originSignature).toBe('0x0a141e');
+            expect(json.signature).toBe('0x28323c');
+            expect(json.gasPayerSignature).toBe('0x46505a');
+        });
+
+        test('ok <- should produce JSON that extends SignedTransactionRequestJSON with gas payer properties', () => {
+            const json = sponsoredTxRequest.toJSON();
+
+            // Verify all TransactionRequestJSON properties exist
+            expect(json).toHaveProperty('blockRef');
+            expect(json).toHaveProperty('chainTag');
+            expect(json).toHaveProperty('clauses');
+            expect(json).toHaveProperty('dependsOn');
+            expect(json).toHaveProperty('expiration');
+            expect(json).toHaveProperty('gas');
+            expect(json).toHaveProperty('gasPriceCoef');
+            expect(json).toHaveProperty('nonce');
+            expect(json).toHaveProperty('isIntendedToBeSponsored');
+
+            // Verify SignedTransactionRequestJSON properties exist
+            expect(json).toHaveProperty('origin');
+            expect(json).toHaveProperty('originSignature');
+            expect(json).toHaveProperty('signature');
+
+            // Verify additional SponsoredTransactionRequestJSON properties exist
+            expect(json).toHaveProperty('gasPayer');
+            expect(json).toHaveProperty('gasPayerSignature');
+
+            // Verify types for gas payer properties
+            expect(typeof json.gasPayer).toBe('string');
+            expect(typeof json.gasPayerSignature).toBe('string');
+
+            // Verify hex format for gas payer properties
+            expect(json.gasPayer.startsWith('0x')).toBe(true);
+            expect(json.gasPayerSignature.startsWith('0x')).toBe(true);
+        });
+
+        test('ok <- should handle defensive copy mutation protection in JSON conversion', () => {
+            // Modify the original signature arrays after construction
+            const originalGasPayerSignature = new Uint8Array(
+                mockParams.gasPayerSignature
+            );
+
+            mockParams.gasPayerSignature[0] = 255;
+
+            const json = sponsoredTxRequest.toJSON();
+
+            // The JSON should reflect the original values, not the modified ones
+            expect(json.gasPayerSignature).toBe('0x0b0c0d0e0f');
+
+            // Restore original values for other tests
+            mockParams.gasPayerSignature.set(originalGasPayerSignature);
+        });
+
+        test('ok <- should maintain consistency with different gas payer addresses', () => {
+            const differentGasPayerParams = {
+                ...mockParams,
+                gasPayer: Address.of(
+                    '0x1234567890123456789012345678901234567890'
+                )
+            };
+            const sponsoredRequestWithDifferentGasPayer =
+                new SponsoredTransactionRequest(differentGasPayerParams);
+
+            const json = sponsoredRequestWithDifferentGasPayer.toJSON();
+
+            expect(json.gasPayer).toBe(
+                '0x1234567890123456789012345678901234567890'
+            );
+            expect(json.origin).toBe(mockParams.origin.toString());
+            expect(json.gasPayer).not.toBe(json.origin);
+        });
+
+        test('ok <- should handle sponsored transaction with isIntendedToBeSponsored true', () => {
+            // This should always be true for sponsored transactions
+            expect(sponsoredTxRequest.isIntendedToBeSponsored).toBe(true);
+
+            const json = sponsoredTxRequest.toJSON();
+
+            expect(json.isIntendedToBeSponsored).toBe(true);
         });
     });
 });

--- a/packages/sdk/tests/thor/thor-client/transactions/TransactionRequest.unit.test.ts
+++ b/packages/sdk/tests/thor/thor-client/transactions/TransactionRequest.unit.test.ts
@@ -148,4 +148,204 @@ describe('TransactionRequest UNIT tests', () => {
             expect(request.isSigned()).toBe(false);
         });
     });
+
+    describe('toJSON', () => {
+        test('ok <- should convert TransactionRequest to JSON with all properties', () => {
+            const request = new TransactionRequest({
+                blockRef: validBlockRef,
+                chainTag: validChainTag,
+                clauses: validClauses,
+                dependsOn: validDependsOn,
+                expiration: validExpiration,
+                gas: validGas,
+                gasPriceCoef: validGasPriceCoef,
+                nonce: validNonce,
+                isIntendedToBeSponsored: true
+            });
+
+            const json = request.toJSON();
+
+            expect(json.blockRef).toBe(validBlockRef.toString());
+            expect(json.chainTag).toBe(validChainTag);
+            expect(json.clauses).toHaveLength(1);
+            expect(json.clauses[0]).toEqual(validClause.toJSON());
+            expect(json.dependsOn).toBe(validDependsOn.toString());
+            expect(json.expiration).toBe(validExpiration);
+            expect(json.gas).toBe(validGas);
+            expect(json.gasPriceCoef).toBe(validGasPriceCoef);
+            expect(json.nonce).toBe(validNonce);
+            expect(json.isIntendedToBeSponsored).toBe(true);
+        });
+
+        test('ok <- should convert TransactionRequest to JSON with null dependsOn', () => {
+            const request = new TransactionRequest({
+                blockRef: validBlockRef,
+                chainTag: validChainTag,
+                clauses: validClauses,
+                dependsOn: null,
+                expiration: validExpiration,
+                gas: validGas,
+                gasPriceCoef: validGasPriceCoef,
+                nonce: validNonce,
+                isIntendedToBeSponsored: false
+            });
+
+            const json = request.toJSON();
+
+            expect(json.dependsOn).toBeNull();
+            expect(json.isIntendedToBeSponsored).toBe(false);
+        });
+
+        test('ok <- should convert TransactionRequest to JSON with empty clauses array', () => {
+            const request = new TransactionRequest({
+                blockRef: validBlockRef,
+                chainTag: validChainTag,
+                clauses: [],
+                dependsOn: null,
+                expiration: validExpiration,
+                gas: validGas,
+                gasPriceCoef: validGasPriceCoef,
+                nonce: validNonce
+            });
+
+            const json = request.toJSON();
+
+            expect(json.clauses).toEqual([]);
+            expect(Array.isArray(json.clauses)).toBe(true);
+        });
+
+        test('ok <- should convert TransactionRequest to JSON with multiple clauses', () => {
+            const clause1 = new Clause(
+                Address.of('0x9e7911de289c3c856ce7f421034f66b6cde49c39'),
+                1n,
+                null,
+                null,
+                null
+            );
+            const clause2 = new Clause(
+                Address.of('0x8e7911de289c3c856ce7f421034f66b6cde49c38'),
+                2n,
+                HexUInt.of('0x12345'),
+                'Test clause',
+                null
+            );
+
+            const request = new TransactionRequest({
+                blockRef: validBlockRef,
+                chainTag: validChainTag,
+                clauses: [clause1, clause2],
+                dependsOn: null,
+                expiration: validExpiration,
+                gas: validGas,
+                gasPriceCoef: validGasPriceCoef,
+                nonce: validNonce
+            });
+
+            const json = request.toJSON();
+
+            expect(json.clauses).toHaveLength(2);
+            expect(json.clauses[0]).toEqual(clause1.toJSON());
+            expect(json.clauses[1]).toEqual(clause2.toJSON());
+        });
+
+        test('ok <- should convert TransactionRequest to JSON with default isIntendedToBeSponsored', () => {
+            const request = new TransactionRequest({
+                blockRef: validBlockRef,
+                chainTag: validChainTag,
+                clauses: validClauses,
+                dependsOn: null,
+                expiration: validExpiration,
+                gas: validGas,
+                gasPriceCoef: validGasPriceCoef,
+                nonce: validNonce
+                // isIntendedToBeSponsored not provided, should default to false
+            });
+
+            const json = request.toJSON();
+
+            expect(json.isIntendedToBeSponsored).toBe(false);
+        });
+
+        test('ok <- should convert TransactionRequest to JSON with bigint values preserved', () => {
+            const largeGas = 999999999999999999n;
+            const largeGasPriceCoef = 123456789n;
+
+            const request = new TransactionRequest({
+                blockRef: validBlockRef,
+                chainTag: validChainTag,
+                clauses: validClauses,
+                dependsOn: null,
+                expiration: validExpiration,
+                gas: largeGas,
+                gasPriceCoef: largeGasPriceCoef,
+                nonce: validNonce
+            });
+
+            const json = request.toJSON();
+
+            expect(json.gas).toBe(largeGas);
+            expect(json.gasPriceCoef).toBe(largeGasPriceCoef);
+            expect(typeof json.gas).toBe('bigint');
+            expect(typeof json.gasPriceCoef).toBe('bigint');
+        });
+
+        test('ok <- should convert TransactionRequest to JSON with all string values properly formatted', () => {
+            const request = new TransactionRequest({
+                blockRef: validBlockRef,
+                chainTag: validChainTag,
+                clauses: validClauses,
+                dependsOn: validDependsOn,
+                expiration: validExpiration,
+                gas: validGas,
+                gasPriceCoef: validGasPriceCoef,
+                nonce: validNonce
+            });
+
+            const json = request.toJSON();
+
+            expect(typeof json.blockRef).toBe('string');
+            expect(typeof json.dependsOn).toBe('string');
+            expect(json.blockRef.startsWith('0x')).toBe(true);
+            expect(json.dependsOn?.startsWith('0x')).toBe(true);
+        });
+
+        test('ok <- should produce JSON that satisfies TransactionRequestJSON interface', () => {
+            const request = new TransactionRequest({
+                blockRef: validBlockRef,
+                chainTag: validChainTag,
+                clauses: validClauses,
+                dependsOn: validDependsOn,
+                expiration: validExpiration,
+                gas: validGas,
+                gasPriceCoef: validGasPriceCoef,
+                nonce: validNonce,
+                isIntendedToBeSponsored: true
+            });
+
+            const json = request.toJSON();
+
+            // Verify all required properties exist and have correct types
+            expect(json).toHaveProperty('blockRef');
+            expect(json).toHaveProperty('chainTag');
+            expect(json).toHaveProperty('clauses');
+            expect(json).toHaveProperty('dependsOn');
+            expect(json).toHaveProperty('expiration');
+            expect(json).toHaveProperty('gas');
+            expect(json).toHaveProperty('gasPriceCoef');
+            expect(json).toHaveProperty('nonce');
+            expect(json).toHaveProperty('isIntendedToBeSponsored');
+
+            expect(typeof json.blockRef).toBe('string');
+            expect(typeof json.chainTag).toBe('number');
+            expect(Array.isArray(json.clauses)).toBe(true);
+            expect(
+                typeof json.dependsOn === 'string' || json.dependsOn === null
+            ).toBe(true);
+            expect(typeof json.expiration).toBe('number');
+            expect(typeof json.gas).toBe('bigint');
+            expect(typeof json.gasPriceCoef).toBe('bigint');
+            expect(typeof json.nonce).toBe('number');
+            expect(typeof json.isIntendedToBeSponsored).toBe('boolean');
+        });
+    });
 });

--- a/packages/sdk/tests/viem/clients/WalletClient.unit.test.ts
+++ b/packages/sdk/tests/viem/clients/WalletClient.unit.test.ts
@@ -1,20 +1,22 @@
-import type { RegularBlockResponseJSON } from '@thor/thorest/json';
 import {
-    ClauseBuilder,
-    Transaction,
-    type TransactionBody
-} from '@thor/thorest';
-import { Address, BlockRef, Hex, HexUInt } from '@common/vcdm';
+    Clause,
+    SignedTransactionRequest,
+    TransactionRequest
+} from '@thor/thor-client/model/transactions';
+import { ThorError } from '@thor/thorest';
+import { Address, BlockRef, Hex, HexUInt, Quantity } from '@common/vcdm';
 import { SOLO_NETWORK } from '@thor/utils';
 import { TEST_ACCOUNTS } from '../../fixture';
 import { privateKeyToAccount } from 'viem/accounts';
-import { expect } from '@jest/globals';
+import { describe, expect, test } from '@jest/globals';
 import {
     createWalletClient,
-    type PrepareTransactionRequestRequest
+    type PrepareTransactionRequestRequest,
+    WalletClient
 } from '@viem/clients';
 import { mockHttpClient } from '../../MockHttpClient';
-import { log } from '@common/logging';
+import { PrivateKeySigner, RLPCodecTransactionRequest } from '@thor';
+import { IllegalArgumentError, UnsupportedOperationError } from '@common';
 
 const { TRANSACTION_SENDER, TRANSACTION_RECEIVER } = TEST_ACCOUNTS.TRANSACTION;
 
@@ -24,48 +26,121 @@ const MOCK_URL = new URL('https://mock-url');
  * @group unit/clients
  */
 describe('WalletClient UNIT tests', () => {
-    describe('prepareTransactionRequest', () => {
-        test('ok <- thor and viem equivalence', () => {
-            const latestBlock = {
-                number: 88,
-                id: '0x00000058f9f240032e073f4a078c5f0f3e04ae7272e4550de41f10723d6f8b2e',
-                size: 364,
-                parentID:
-                    '0x000000577127e6426fbe5a303755ba64c167f173bb4e9b60156a62bced1551d8',
-                timestamp: 1749224420,
-                gasLimit: '150000000',
-                beneficiary: '0xf077b491b355e64048ce21e3a6fc4751eeea77fa',
-                gasUsed: '0',
-                totalScore: 88,
-                txsRoot:
-                    '0x45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0',
-                txsFeatures: 1,
-                stateRoot:
-                    '0xe030c534b66bd1c1b156ada9508bd639cdcbeb7ea1e932f4fd998857b3c4f30a',
-                receiptsRoot:
-                    '0x45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0',
-                com: false,
-                signer: '0xf077b491b355e64048ce21e3a6fc4751eeea77fa',
-                isTrunk: true,
-                isFinalized: false,
-                baseFeePerGas: '0x9184e72a000',
-                transactions: []
-            } satisfies RegularBlockResponseJSON;
-            const transferClause = ClauseBuilder.transferVET(
-                Address.of(TRANSACTION_RECEIVER.address),
-                1n
+    const mockBlockRef = BlockRef.of('0x1234567890abcdef');
+    const mockGas = 21000n;
+    const mockValue = Quantity.of(1000);
+
+    const mockOriginSigner = new PrivateKeySigner(
+        HexUInt.of(TRANSACTION_SENDER.privateKey).bytes
+    );
+
+    const mockGasPayerSigner = new PrivateKeySigner(
+        HexUInt.of(TRANSACTION_RECEIVER.privateKey).bytes
+    );
+
+    describe('constructor', () => {
+        test('ok <- create WalletClient with account', () => {
+            const account = privateKeyToAccount(
+                `0x${TRANSACTION_SENDER.privateKey}`
             );
-            const txBody: TransactionBody = {
+            const walletClient = new WalletClient(
+                MOCK_URL,
+                mockHttpClient({}, 'post'),
+                account
+            );
+            expect(walletClient).toBeInstanceOf(WalletClient);
+            expect(walletClient.getAddresses()).toHaveLength(1);
+        });
+
+        test('ok <- create WalletClient without account', () => {
+            const walletClient = new WalletClient(
+                MOCK_URL,
+                mockHttpClient({}, 'post'),
+                null
+            );
+            expect(walletClient).toBeInstanceOf(WalletClient);
+            expect(walletClient.getAddresses()).toHaveLength(0);
+        });
+    });
+
+    describe('createWalletClient', () => {
+        test('ok <- create WalletClient with provided transport', () => {
+            const account = privateKeyToAccount(
+                `0x${TRANSACTION_SENDER.privateKey}`
+            );
+            const transport = mockHttpClient({}, 'post');
+            const walletClient = createWalletClient({
+                network: MOCK_URL,
+                transport,
+                account
+            });
+            expect(walletClient).toBeInstanceOf(WalletClient);
+        });
+
+        test('ok <- create WalletClient with default transport', () => {
+            const account = privateKeyToAccount(
+                `0x${TRANSACTION_SENDER.privateKey}`
+            );
+            const walletClient = createWalletClient({
+                network: MOCK_URL,
+                account
+            });
+            expect(walletClient).toBeInstanceOf(WalletClient);
+        });
+
+        test('ok <- create WalletClient without account', () => {
+            const walletClient = createWalletClient({
+                network: MOCK_URL
+            });
+            expect(walletClient).toBeInstanceOf(WalletClient);
+            expect(walletClient.getAddresses()).toHaveLength(0);
+        });
+    });
+
+    describe('getAddresses', () => {
+        test('ok <- return account address when account is set', () => {
+            const account = privateKeyToAccount(
+                `0x${TRANSACTION_SENDER.privateKey}`
+            );
+            const walletClient = createWalletClient({
+                network: MOCK_URL,
+                transport: mockHttpClient({}, 'post'),
+                account
+            });
+            const addresses = walletClient.getAddresses();
+            expect(addresses).toHaveLength(1);
+            expect(addresses[0].toString().toLowerCase()).toBe(
+                account.address.toLowerCase()
+            );
+        });
+
+        test('ok <- return empty array when account is null', () => {
+            const walletClient = createWalletClient({
+                network: MOCK_URL,
+                transport: mockHttpClient({}, 'post')
+            });
+            const addresses = walletClient.getAddresses();
+            expect(addresses).toHaveLength(0);
+        });
+    });
+
+    describe('prepareTransactionRequest', () => {
+        test('ok <- test Viem PrepareTransactionRequestRequest and Thor TransactionRequest equivalence', () => {
+            const expected = new TransactionRequest({
+                blockRef: mockBlockRef,
                 chainTag: SOLO_NETWORK.chainTag,
-                blockRef: BlockRef.of(latestBlock.id).toString(),
-                expiration: 32,
-                clauses: [transferClause],
-                gasPriceCoef: 0,
-                gas: 100000,
+                clauses: [
+                    Clause.of({
+                        to: TRANSACTION_RECEIVER.address,
+                        value: mockValue.toString()
+                    })
+                ],
                 dependsOn: null,
-                nonce: 8
-            };
-            const expected = Transaction.of(txBody);
+                expiration: 32,
+                gas: mockGas,
+                gasPriceCoef: 0n,
+                nonce: 3
+            });
 
             const account = privateKeyToAccount(
                 `0x${TRANSACTION_SENDER.privateKey}`
@@ -76,73 +151,20 @@ describe('WalletClient UNIT tests', () => {
                 account
             });
             const request: PrepareTransactionRequestRequest = {
-                to: Address.of(transferClause.to as string),
-                value: Hex.of(transferClause.value),
-                blockRef: Hex.of(txBody.blockRef),
-                chainTag: txBody.chainTag,
-                expiration: txBody.expiration,
-                gas: txBody.gas as number,
-                nonce: txBody.nonce,
-                gasPriceCoef: 0
+                to: expected.clauses[0].to as Address,
+                value: HexUInt.of(expected.clauses[0].value),
+                blockRef: expected.blockRef,
+                chainTag: expected.chainTag,
+                expiration: expected.expiration,
+                gas: HexUInt.of(expected.gas),
+                nonce: expected.nonce,
+                gasPriceCoef: Number(expected.gasPriceCoef)
             } satisfies PrepareTransactionRequestRequest;
             const actual = walletClient.prepareTransactionRequest(request);
-            expect(actual.encoded).toEqual(expected.encoded);
+            expect(actual.toJSON()).toEqual(expected.toJSON());
         });
-    });
 
-    describe('signTransaction', () => {
-        test('ok <- thor and viem equivalence', async () => {
-            const latestBlock = {
-                number: 88,
-                id: '0x00000058f9f240032e073f4a078c5f0f3e04ae7272e4550de41f10723d6f8b2e',
-                size: 364,
-                parentID:
-                    '0x000000577127e6426fbe5a303755ba64c167f173bb4e9b60156a62bced1551d8',
-                timestamp: 1749224420,
-                gasLimit: '150000000',
-                beneficiary: '0xf077b491b355e64048ce21e3a6fc4751eeea77fa',
-                gasUsed: '0',
-                totalScore: 88,
-                txsRoot:
-                    '0x45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0',
-                txsFeatures: 1,
-                stateRoot:
-                    '0xe030c534b66bd1c1b156ada9508bd639cdcbeb7ea1e932f4fd998857b3c4f30a',
-                receiptsRoot:
-                    '0x45b0cfc220ceec5b7c1c62c4d4193d38e4eba48e8815729ce75f9c0ab0e4c1c0',
-                com: false,
-                signer: '0xf077b491b355e64048ce21e3a6fc4751eeea77fa',
-                isTrunk: true,
-                isFinalized: false,
-                baseFeePerGas: '0x9184e72a000',
-                transactions: []
-            } satisfies RegularBlockResponseJSON;
-            const transferClause = ClauseBuilder.transferVET(
-                Address.of(TRANSACTION_RECEIVER.address),
-                1n
-            );
-            const txBody: TransactionBody = {
-                chainTag: SOLO_NETWORK.chainTag,
-                blockRef: latestBlock.id.toString().slice(0, 18),
-                expiration: 32,
-                clauses: [transferClause],
-                gasPriceCoef: 0,
-                gas: 100000,
-                dependsOn: null,
-                nonce: 8
-            };
-
-            const signedTx = Transaction.of(txBody).sign(
-                HexUInt.of(TRANSACTION_SENDER.privateKey).bytes
-            );
-            const thorSigned = HexUInt.of(signedTx.encoded);
-            log({
-                verbosity: 'debug',
-                message: 'thorSigned',
-                source: 'WalletClient.unit.test',
-                context: { thorSigned: thorSigned.toString() }
-            });
-
+        test('ok <- prepare transaction request with numeric value', () => {
             const account = privateKeyToAccount(
                 `0x${TRANSACTION_SENDER.privateKey}`
             );
@@ -151,15 +173,466 @@ describe('WalletClient UNIT tests', () => {
                 transport: mockHttpClient({}, 'post'),
                 account
             });
-            const tx = Transaction.of(txBody);
-            const signedViem = await walletClient.signTransaction(tx);
-            log({
-                verbosity: 'debug',
-                message: 'signedViem',
-                source: 'WalletClient.unit.test',
-                context: { signedViem: signedViem.toString() }
+
+            const request: PrepareTransactionRequestRequest = {
+                to: Address.of(TRANSACTION_RECEIVER.address),
+                value: 1000,
+                blockRef: mockBlockRef,
+                chainTag: SOLO_NETWORK.chainTag,
+                expiration: 32,
+                gas: 21000,
+                nonce: 3,
+                gasPriceCoef: 0
+            };
+
+            const result = walletClient.prepareTransactionRequest(request);
+            expect(result).toBeInstanceOf(TransactionRequest);
+            expect(result.clauses[0].value).toBe(1000n);
+        });
+
+        test('ok <- prepare transaction request with optional fields', () => {
+            const account = privateKeyToAccount(
+                `0x${TRANSACTION_SENDER.privateKey}`
+            );
+            const walletClient = createWalletClient({
+                network: MOCK_URL,
+                transport: mockHttpClient({}, 'post'),
+                account
             });
-            expect(signedViem.toString()).toEqual(thorSigned.toString());
+
+            const dependsOn = Hex.of('0xabcdef1234567890');
+            const data = Hex.of('0x1234');
+            const comment = 'test comment';
+            const abi = Hex.of('0x5678');
+
+            const request: PrepareTransactionRequestRequest = {
+                to: Address.of(TRANSACTION_RECEIVER.address),
+                value: HexUInt.of(1000),
+                data,
+                comment,
+                abi,
+                blockRef: mockBlockRef,
+                chainTag: SOLO_NETWORK.chainTag,
+                dependsOn,
+                expiration: 32,
+                gas: HexUInt.of(21000),
+                nonce: 3,
+                gasPriceCoef: 0,
+                isIntendedToBeSponsored: true
+            };
+
+            const result = walletClient.prepareTransactionRequest(request);
+            expect(result).toBeInstanceOf(TransactionRequest);
+            expect(result.dependsOn).toEqual(dependsOn);
+            expect(result.isIntendedToBeSponsored).toBe(true);
+            expect(result.clauses[0].data).toEqual(HexUInt.of(data));
+            expect(result.clauses[0].comment).toBe(comment);
+        });
+
+        test('err <- throw UnsupportedOperationError for invalid request', () => {
+            const account = privateKeyToAccount(
+                `0x${TRANSACTION_SENDER.privateKey}`
+            );
+            const walletClient = createWalletClient({
+                network: MOCK_URL,
+                transport: mockHttpClient({}, 'post'),
+                account
+            });
+
+            // Create an invalid request that will cause an error during processing
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+            const invalidRequest = {
+                value: 'invalid', // This should cause an error
+                blockRef: mockBlockRef,
+                chainTag: SOLO_NETWORK.chainTag,
+                expiration: 32,
+                gas: 21000,
+                nonce: 3,
+                gasPriceCoef: 0
+            } as unknown as PrepareTransactionRequestRequest;
+
+            expect(() =>
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                walletClient.prepareTransactionRequest(invalidRequest)
+            ).toThrow(UnsupportedOperationError);
+        });
+
+        test('ok <- handle transaction request with all optional fields as undefined', () => {
+            const account = privateKeyToAccount(
+                `0x${TRANSACTION_SENDER.privateKey}`
+            );
+            const walletClient = createWalletClient({
+                network: MOCK_URL,
+                transport: mockHttpClient({}, 'post'),
+                account
+            });
+
+            const request: PrepareTransactionRequestRequest = {
+                value: 1000,
+                blockRef: mockBlockRef,
+                chainTag: SOLO_NETWORK.chainTag,
+                expiration: 32,
+                gas: 21000,
+                nonce: 3,
+                gasPriceCoef: 0
+                // All optional fields are undefined
+            };
+
+            const result = walletClient.prepareTransactionRequest(request);
+            expect(result).toBeInstanceOf(TransactionRequest);
+            expect(result.clauses[0].to).toBeNull();
+            expect(result.dependsOn).toBeNull();
+            expect(result.isIntendedToBeSponsored).toBe(false);
+        });
+    });
+
+    describe('sendTransaction', () => {
+        test('ok <- send transaction from PrepareTransactionRequestRequest', async () => {
+            const expected = {
+                id: Hex.of(
+                    '0x0000000000000000000000000000000000000000000000001234567890abcdef'
+                )
+            };
+            const transport = mockHttpClient(expected, 'post');
+
+            const account = privateKeyToAccount(
+                `0x${TRANSACTION_SENDER.privateKey}`
+            );
+            const walletClient = createWalletClient({
+                network: MOCK_URL,
+                transport,
+                account
+            });
+
+            const request: PrepareTransactionRequestRequest = {
+                to: Address.of(TRANSACTION_RECEIVER.address),
+                value: 1000,
+                blockRef: mockBlockRef,
+                chainTag: SOLO_NETWORK.chainTag,
+                expiration: 32,
+                gas: 21000,
+                nonce: 3,
+                gasPriceCoef: 0
+            };
+
+            const actual = await walletClient.sendTransaction(request);
+            expect(actual.toString()).toEqual(expected.id.toString());
+        });
+
+        test('ok <- send transaction from SignedTransactionRequest', async () => {
+            const expected = {
+                id: Hex.of(
+                    '0x0000000000000000000000000000000000000000000000001234567890abcdef'
+                )
+            };
+            const transport = mockHttpClient(expected, 'post');
+
+            const gasPayerAccount = privateKeyToAccount(
+                `0x${TRANSACTION_RECEIVER.privateKey}`
+            );
+            const gasPayerWallet = createWalletClient({
+                network: MOCK_URL,
+                transport,
+                account: gasPayerAccount
+            });
+
+            // Create a signed transaction request that is intended to be sponsored
+            const signedTxRequest = mockOriginSigner.sign(
+                new TransactionRequest({
+                    blockRef: mockBlockRef,
+                    chainTag: 1,
+                    clauses: [
+                        Clause.of({
+                            to: TRANSACTION_RECEIVER.address,
+                            value: '1000'
+                        })
+                    ],
+                    dependsOn: null,
+                    expiration: 32,
+                    gas: mockGas,
+                    gasPriceCoef: 0n,
+                    nonce: 3,
+                    isIntendedToBeSponsored: true
+                })
+            );
+
+            const actual =
+                await gasPayerWallet.sendTransaction(signedTxRequest);
+            expect(actual.toString()).toEqual(expected.id.toString());
+        });
+
+        test('err <- throw UnsupportedOperationError when account is not set', async () => {
+            const walletClient = createWalletClient({
+                network: MOCK_URL,
+                transport: mockHttpClient({}, 'post')
+            });
+
+            const request: PrepareTransactionRequestRequest = {
+                to: Address.of(TRANSACTION_RECEIVER.address),
+                value: 1000,
+                blockRef: mockBlockRef,
+                chainTag: SOLO_NETWORK.chainTag,
+                expiration: 32,
+                gas: 21000,
+                nonce: 3,
+                gasPriceCoef: 0
+            };
+
+            await expect(walletClient.sendTransaction(request)).rejects.toThrow(
+                UnsupportedOperationError
+            );
+        });
+    });
+
+    describe('sendRawTransaction', () => {
+        test('ok <- send raw transaction successfully', async () => {
+            const expected = {
+                id: Hex.of(
+                    '0x0000000000000000000000000000000000000000000000001234567890abcdef'
+                )
+            };
+            const transport = mockHttpClient(expected, 'post');
+
+            const account = privateKeyToAccount(
+                `0x${TRANSACTION_SENDER.privateKey}`
+            );
+            const walletClient = createWalletClient({
+                network: MOCK_URL,
+                transport,
+                account
+            });
+
+            const rawTx = Hex.of('0x1234567890abcdef');
+            const actual = await walletClient.sendRawTransaction(rawTx);
+
+            expect(actual.toString()).toEqual(expected.id.toString());
+        });
+
+        test('err <- throw ThorError when sending raw transaction fails', async () => {
+            const transport = mockHttpClient(null, 'post', true); // Mock error
+
+            const account = privateKeyToAccount(
+                `0x${TRANSACTION_SENDER.privateKey}`
+            );
+            const walletClient = createWalletClient({
+                network: MOCK_URL,
+                transport,
+                account
+            });
+
+            const rawTx = Hex.of('0x1234567890abcdef');
+            await expect(
+                walletClient.sendRawTransaction(rawTx)
+            ).rejects.toThrow(ThorError);
+        });
+    });
+
+    describe('signTransaction', () => {
+        test('ok <- sign a not-sponsored unsigned transaction request', async () => {
+            const txRequest = new TransactionRequest({
+                blockRef: mockBlockRef,
+                chainTag: SOLO_NETWORK.chainTag,
+                clauses: [
+                    Clause.of({
+                        to: TRANSACTION_RECEIVER.address,
+                        value: mockValue.toString()
+                    })
+                ],
+                dependsOn: null,
+                expiration: 32,
+                gas: mockGas,
+                gasPriceCoef: 0n,
+                nonce: 3
+            });
+            const expected = mockOriginSigner.sign(txRequest);
+            const originAccount = privateKeyToAccount(
+                `0x${TRANSACTION_SENDER.privateKey}`
+            );
+            const originWallet = createWalletClient({
+                network: MOCK_URL,
+                transport: mockHttpClient({}, 'post'),
+                account: originAccount
+            });
+            const encoded = await originWallet.signTransaction(txRequest);
+            const actual = RLPCodecTransactionRequest.decode(encoded.bytes);
+            expect(actual.toJSON()).toEqual(expected.toJSON());
+        });
+
+        test('ok <- sign a sponsored unsigned transaction request', async () => {
+            const txRequest = new TransactionRequest({
+                blockRef: mockBlockRef,
+                chainTag: 1,
+                clauses: [
+                    Clause.of({
+                        to: TRANSACTION_RECEIVER.address,
+                        value: mockValue.toString()
+                    })
+                ],
+                dependsOn: null,
+                expiration: 32,
+                gas: mockGas,
+                gasPriceCoef: 0n,
+                nonce: 3,
+                isIntendedToBeSponsored: true
+            });
+            const expected = mockOriginSigner.sign(txRequest);
+
+            const originAccount = privateKeyToAccount(
+                `0x${TRANSACTION_SENDER.privateKey}`
+            );
+            const originWallet = createWalletClient({
+                network: MOCK_URL,
+                transport: mockHttpClient({}, 'post'),
+                account: originAccount
+            });
+            const actual = RLPCodecTransactionRequest.decode(
+                (await originWallet.signTransaction(txRequest)).bytes
+            );
+            expect(actual.toJSON()).toEqual(expected.toJSON());
+        });
+
+        test('ok <- sponsor a sponsored signed transaction request', async () => {
+            const txRequest = new TransactionRequest({
+                blockRef: mockBlockRef,
+                chainTag: 1,
+                clauses: [
+                    Clause.of({
+                        to: TRANSACTION_RECEIVER.address,
+                        value: mockValue.toString()
+                    })
+                ],
+                dependsOn: null,
+                expiration: 32,
+                gas: mockGas,
+                gasPriceCoef: 0n,
+                nonce: 3,
+                isIntendedToBeSponsored: true
+            });
+            const expected = mockGasPayerSigner.sign(
+                mockOriginSigner.sign(txRequest)
+            );
+
+            const originAccount = privateKeyToAccount(
+                `0x${TRANSACTION_SENDER.privateKey}`
+            );
+            const originWallet = createWalletClient({
+                network: MOCK_URL,
+                transport: mockHttpClient({}, 'post'),
+                account: originAccount
+            });
+            const signedTxRequest = RLPCodecTransactionRequest.decode(
+                (await originWallet.signTransaction(txRequest)).bytes
+            );
+
+            const gasPayerAccount = privateKeyToAccount(
+                `0x${TRANSACTION_RECEIVER.privateKey}`
+            );
+            const gasPayerWallet = createWalletClient({
+                network: MOCK_URL,
+                transport: mockHttpClient({}, 'post'),
+                account: gasPayerAccount
+            });
+            const actual = RLPCodecTransactionRequest.decode(
+                (await gasPayerWallet.signTransaction(signedTxRequest)).bytes
+            );
+            expect(actual.toJSON()).toEqual(expected.toJSON());
+        });
+
+        test('err <- throw UnsupportedOperationError when account is null', async () => {
+            const walletClient = createWalletClient({
+                network: MOCK_URL,
+                transport: mockHttpClient({}, 'post')
+            });
+
+            const txRequest = new TransactionRequest({
+                blockRef: mockBlockRef,
+                chainTag: SOLO_NETWORK.chainTag,
+                clauses: [
+                    Clause.of({
+                        to: TRANSACTION_RECEIVER.address,
+                        value: '1000'
+                    })
+                ],
+                dependsOn: null,
+                expiration: 32,
+                gas: mockGas,
+                gasPriceCoef: 0n,
+                nonce: 3
+            });
+
+            await expect(
+                walletClient.signTransaction(txRequest)
+            ).rejects.toThrow(UnsupportedOperationError);
+        });
+
+        test('err <- throw UnsupportedOperationError when account has not sign method', async () => {
+            // Create a mock account without sign method
+            const invalidAccount = {
+                address: TRANSACTION_SENDER.address,
+                type: 'local' as const
+            };
+
+            const walletClient = new WalletClient(
+                MOCK_URL,
+                mockHttpClient({}, 'post'),
+                invalidAccount as unknown
+            );
+
+            const txRequest = new TransactionRequest({
+                blockRef: mockBlockRef,
+                chainTag: SOLO_NETWORK.chainTag,
+                clauses: [
+                    Clause.of({
+                        to: TRANSACTION_RECEIVER.address,
+                        value: '1000'
+                    })
+                ],
+                dependsOn: null,
+                expiration: 32,
+                gas: mockGas,
+                gasPriceCoef: 0n,
+                nonce: 3
+            });
+
+            await expect(
+                walletClient.signTransaction(txRequest)
+            ).rejects.toThrow(UnsupportedOperationError);
+        });
+
+        test('err <- throw IllegalArgumentError when SignedTransactionRequest is not intended to be sponsored', async () => {
+            const originAccount = privateKeyToAccount(
+                `0x${TRANSACTION_SENDER.privateKey}`
+            );
+            const originWallet = createWalletClient({
+                network: MOCK_URL,
+                transport: mockHttpClient({}, 'post'),
+                account: originAccount
+            });
+
+            // Create a signed transaction request that is not intended to be sponsored
+            const signedTxRequest = new SignedTransactionRequest({
+                blockRef: mockBlockRef,
+                chainTag: 1,
+                clauses: [
+                    Clause.of({
+                        to: TRANSACTION_RECEIVER.address,
+                        value: '1000'
+                    })
+                ],
+                dependsOn: null,
+                expiration: 32,
+                gas: mockGas,
+                gasPriceCoef: 0n,
+                nonce: 3,
+                isIntendedToBeSponsored: false,
+                origin: Address.of(TRANSACTION_SENDER.address),
+                originSignature: new Uint8Array(65),
+                signature: new Uint8Array(65)
+            });
+
+            await expect(
+                originWallet.signTransaction(signedTxRequest)
+            ).rejects.toThrow(IllegalArgumentError);
         });
     });
 });


### PR DESCRIPTION
# Description

Viem walletClient returns an hex encoding of a SignedTransactionRequest or a SponsoredTransactionRequest.
To allow the Viem walletClient to .signTransaction from SignedTransaction request as gar payer, it needs to decode a previously signed transaction that is returned as a hex expression.
RLPCodec must support the decode for

- TransactionRequest
- SignedTransactionRequest
- SponsoredTransactionRequest

allowing the Viem layer user to ignore everything about the thor module.


Fixes # 2404

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
- [x] Test B

**Test Configuration**:
* Node.js Version:
* Yarn Version:

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code