### PR TITLE
fix: unnecessary fetch polyfill node

### DIFF
--- a/packages/sdk/jest.node-setup.js
+++ b/packages/sdk/jest.node-setup.js
@@ -1,11 +1,7 @@
 // Jest setup for Node.js environment
-require('whatwg-fetch');
-const fetchMock = require('jest-fetch-mock');
 const WebSocket = require('ws');
 const { LoggerRegistry, PrettyLogger } = require('@common/logging');
 
-// Don't auto-enable fetch mocks
-fetchMock.dontMock();
 
 // Polyfill WebSocket for Node.js environment
 if (typeof global !== 'undefined' && typeof global.WebSocket === 'undefined') {

--- a/packages/sdk/src/common/http/FetchHttpClient.ts
+++ b/packages/sdk/src/common/http/FetchHttpClient.ts
@@ -217,10 +217,11 @@ class FetchHttpClient implements HttpClient {
                     signal: abortSignal?.signal ?? null
                 };
                 const request = new RequestClass(pathUrl, requestInit);
+                const requestClone = request.clone();
                 const response = await this.fetchFunction(
                     this.options.onRequest?.(request) ?? request
                 );
-                await this.logResponse(request, response);
+                await this.logResponse(requestClone, response);
 
                 // Check for non-200 responses and raise HttpException
                 if (!response.ok) {
@@ -351,10 +352,11 @@ class FetchHttpClient implements HttpClient {
                     signal: abortSignal?.signal ?? null
                 };
                 const request = new RequestClass(pathUrl, requestInit);
+                const requestClone = request.clone();
                 const response = await this.fetchFunction(
                     this.options.onRequest?.(request) ?? request
                 );
-                await this.logResponse(request, response);
+                await this.logResponse(requestClone, response);
 
                 // Check for non-200 responses and raise HttpException
                 if (!response.ok) {
@@ -454,15 +456,14 @@ class FetchHttpClient implements HttpClient {
 
     /**
      * Logs the request and response details.
-     * @param request - The request to log.
+     * @param requestClone - The already cloned request to log.
      * @param response - The response to log.
      */
     private async logResponse(
-        request: Request,
+        requestClone: Request,
         response: Response
     ): Promise<void> {
         try {
-            const requestClone = request != null ? request.clone() : undefined;
             const responseClone =
                 response != null ? response.clone() : undefined;
             const requestDetails = {


### PR DESCRIPTION
# Description

Removed fetch polyfill for when running tests on node
The polyfill had a different behaviour to plain nodejs fetch, in that Request objects were not considered "consumed", whereas when using plain nodejs fetch, Request objects are consumed as soon as they are used to get a response. This lead to incorrectly logging an error

Note: we keep the polyfill for jest browser tests!

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] local node solo tests
- [x] local browser tests 

**Test Configuration**:
* Node.js Version: v22
* Yarn Version: v4

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code