### PR TITLE
fix: node module resolution

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -33,6 +33,14 @@
       "require": "./dist/viem.js"
     }
   },
+  "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "common": ["dist/common.d.ts"],
+      "thor": ["dist/thor.d.ts"],
+      "viem": ["dist/viem.d.ts"]
+    }
+  },
   "files": [
     "dist",
     "src",


### PR DESCRIPTION
# Description

Projects that had `moduleResolution: "node"` their import statements gave an error
This is because the SDK package.json uses exports to create the /common, /viem, /thor import routes
The "node" resolver is quite old, and couldnt understand this

Fixes #2575 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Local unit tests
- [x] Local solo tests
- [x] manual tests with a "node" project 

**Test Configuration**:
* Node.js Version: v22
* Yarn Version: v4

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code