### PR TITLE
fix: estimate gas to build body

### DIFF
--- a/packages/sdk/src/thor/thor-client/transactions/transactions-module.ts
+++ b/packages/sdk/src/thor/thor-client/transactions/transactions-module.ts
@@ -221,7 +221,7 @@ class TransactionsModule extends AbstractThorModule {
      */
     public async buildTransactionBody(
         clauses: Clause[],
-        gas: BigInt | number,
+        gas: number | bigint,
         options?: TransactionBodyOptions
     ): Promise<TransactionRequest> {
         try {


### PR DESCRIPTION
# Description

Estimate gas returns a bigint but the legacy BuildTransactionBody wants a number
Now BuildTransactionBody will take a number or a bigint parameter, and covert to bigint internally

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] local unit tests
- [x] local solo tests

**Test Configuration**:
* Node.js Version: v22
* Yarn Version: v4

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code