### PR TITLE
feat: fix random methods overload in HexInt and HexUInt

### DIFF
--- a/packages/sdk/src/common/vcdm/Hex.ts
+++ b/packages/sdk/src/common/vcdm/Hex.ts
@@ -337,6 +337,24 @@ class Hex implements VeChainDataModel<Hex> {
     }
 
     /**
+     * Generates cryptographically safe random bytes, validating the requested length.
+     *
+     * @param {number} bytes - The number of bytes to generate.
+     * @throws {IllegalArgumentError} - If the bytes argument is not greater than 0.
+     * @returns {Uint8Array} - A randomly generated sequence of bytes.
+     */
+    protected static randomBytes(bytes: number): Uint8Array {
+        if (bytes > 0) {
+            return nh_utils.randomBytes(bytes);
+        }
+        throw new IllegalArgumentError(
+            `${FQP}Hex.random(bytes: number): Hex`,
+            'bytes argument not > 0',
+            { bytes }
+        );
+    }
+
+    /**
      * Generates a random Hex value of the given number of bytes length.
      *
      * @param {number} bytes - The number of bytes to generate.
@@ -351,16 +369,7 @@ class Hex implements VeChainDataModel<Hex> {
      * * Follow links for additional security notes.
      */
     public static random(bytes: number): Hex {
-        if (bytes > 0) {
-            return Hex.of(nh_utils.randomBytes(bytes));
-        }
-        throw new IllegalArgumentError(
-            `${FQP}Hex.random(bytes: number): Hex`,
-            'bytes argument not > 0',
-            {
-                bytes
-            }
-        );
+        return this.of(this.randomBytes(bytes));
     }
 
     /**

--- a/packages/sdk/src/common/vcdm/HexInt.ts
+++ b/packages/sdk/src/common/vcdm/HexInt.ts
@@ -89,5 +89,16 @@ class HexInt extends Hex {
             );
         }
     }
+
+    /**
+     * Generates a random {@link HexInt} value of the given number of bytes length.
+     *
+     * @param {number} bytes - The number of bytes to generate.
+     * @throws {IllegalArgumentError} - If the bytes argument is not greater than 0.
+     * @returns {HexInt} - A randomly generated HexInt value.
+     */
+    public static random(bytes: number): HexInt {
+        return this.of(this.randomBytes(bytes));
+    }
 }
 export { HexInt };

--- a/packages/sdk/src/common/vcdm/HexUInt.ts
+++ b/packages/sdk/src/common/vcdm/HexUInt.ts
@@ -1,4 +1,4 @@
-import { Hex } from '@common/vcdm';
+import { Hex } from './Hex';
 import { HexInt } from './HexInt';
 import { IllegalArgumentError } from '@common/errors';
 
@@ -89,6 +89,24 @@ class HexUInt extends HexInt {
                 e instanceof Error ? e : undefined
             );
         }
+    }
+
+    /**
+     * Generates a random {@link HexUInt} value with the requested number of bytes.
+     * Ensures the most significant nibble is never `0` so that
+     * `HexUInt.random(bytes).bi.toString(16)` always returns exactly `bytes * 2`
+     * hexadecimal digits.
+     *
+     * @param {number} bytes - The number of bytes to generate.
+     * @throws {IllegalArgumentError} - If the bytes argument is not greater than 0.
+     * @returns {HexUInt} - A randomly generated HexUInt value.
+     */
+    public static random(bytes: number): HexUInt {
+        let candidate: Uint8Array;
+        do {
+            candidate = this.randomBytes(bytes);
+        } while (candidate[0] < 0x10);
+        return this.of(candidate);
     }
 }
 

--- a/packages/sdk/tests/common/vcdm/HexInt.unit.test.ts
+++ b/packages/sdk/tests/common/vcdm/HexInt.unit.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, test } from '@jest/globals';
+import { afterEach, describe, expect, test } from '@jest/globals';
 import { Hex, HexInt } from '@common/vcdm';
 import {
     IllegalArgumentError,
     UnsupportedOperationError
 } from '@common/errors';
+import * as nh_utils from '@noble/hashes/utils';
 
 /**
  * Test HexInt class.
@@ -125,6 +126,29 @@ describe('HexInt class tests', () => {
             expect(ofBi.isEqual(ofBytes)).toBeTruthy();
             expect(ofBytes.isEqual(ofHex)).toBeTruthy();
             expect(ofHex.isEqual(ofN)).toBeTruthy();
+        });
+    });
+
+    describe('random method tests', () => {
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        test('Return a deterministic HexInt when randomBytes is mocked', () => {
+            const bytes = 4;
+            const mockBytes = Uint8Array.of(0xde, 0xad, 0xbe, 0xef);
+            const spy = jest
+                .spyOn(nh_utils, 'randomBytes')
+                .mockReturnValue(mockBytes);
+
+            const hexInt = HexInt.random(bytes);
+            expect(hexInt).toBeInstanceOf(HexInt);
+            expect(hexInt.toString()).toEqual('0xdeadbeef');
+            expect(spy).toHaveBeenCalledWith(bytes);
+        });
+
+        test('Throw for invalid byte length', () => {
+            expect(() => HexInt.random(0)).toThrow(IllegalArgumentError);
         });
     });
 });

--- a/packages/sdk/tests/common/vcdm/HexUInt.unit.test.ts
+++ b/packages/sdk/tests/common/vcdm/HexUInt.unit.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from '@jest/globals';
+import { afterEach, describe, expect, test } from '@jest/globals';
 import { HexUInt } from '@common/vcdm';
 import { IllegalArgumentError } from '@common/errors';
+import * as nh_utils from '@noble/hashes/utils';
 
 /**
  * Test HexUInt class.
@@ -29,6 +30,46 @@ describe('HexUInt class tests', () => {
             expect(ofBi.isEqual(ofBytes)).toBeTruthy();
             expect(ofBytes.isEqual(ofHex)).toBeTruthy();
             expect(ofHex.isEqual(ofN)).toBeTruthy();
+        });
+    });
+
+    describe('random method tests', () => {
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        test('Return a deterministic HexUInt with constant hex length', () => {
+            const bytes = 4;
+            const mockBytes = Uint8Array.of(0x12, 0x34, 0x56, 0x78);
+            const spy = jest
+                .spyOn(nh_utils, 'randomBytes')
+                .mockReturnValue(mockBytes);
+
+            const hexUInt = HexUInt.random(bytes);
+            expect(hexUInt).toBeInstanceOf(HexUInt);
+            expect(hexUInt.toString()).toEqual('0x12345678');
+            expect(hexUInt.bi.toString(16)).toHaveLength(bytes * 2);
+            expect(spy).toHaveBeenCalledWith(bytes);
+        });
+
+        test('Retry when random bytes would introduce a leading zero nibble', () => {
+            const bytes = 2;
+            const invalidBytes = Uint8Array.of(0x03, 0xaa); // Leading nibble 0
+            const validBytes = Uint8Array.of(0xab, 0xcd);
+            const spy = jest
+                .spyOn(nh_utils, 'randomBytes')
+                .mockImplementationOnce(() => invalidBytes)
+                .mockImplementationOnce(() => validBytes);
+
+            const hexUInt = HexUInt.random(bytes);
+
+            expect(hexUInt.toString()).toEqual('0xabcd');
+            expect(hexUInt.bi.toString(16)).toHaveLength(bytes * 2);
+            expect(spy).toHaveBeenCalledTimes(2);
+        });
+
+        test('Throw for invalid byte length', () => {
+            expect(() => HexUInt.random(0)).toThrow(IllegalArgumentError);
         });
     });
 });


### PR DESCRIPTION
# Description

Porting #2678 to v3

Fixes #2675 on v3

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] ran the script against local code
- [x] units

**Test Configuration**:
* Node.js Version:
* Yarn Version:

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code