### PR TITLE
Fix: duplicate query param

### DIFF
--- a/packages/network/src/http/SimpleHttpClient.ts
+++ b/packages/network/src/http/SimpleHttpClient.ts
@@ -122,15 +122,8 @@ class SimpleHttpClient implements HttpClient {
                 url = new URL(path, baseURL);
             }
 
-            if (params?.query && url !== undefined) {
-                Object.entries(params.query).forEach(([key, value]) => {
-                    (url as URL).searchParams.append(key, String(value));
-                });
-            }
-
             if (
-                params?.query !== undefined &&
-                params?.query != null &&
+                params?.query &&
                 url !== undefined
             ) {
                 Object.entries(params.query).forEach(([key, value]) => {

--- a/packages/network/src/http/SimpleHttpClient.ts
+++ b/packages/network/src/http/SimpleHttpClient.ts
@@ -122,10 +122,7 @@ class SimpleHttpClient implements HttpClient {
                 url = new URL(path, baseURL);
             }
 
-            if (
-                params?.query &&
-                url !== undefined
-            ) {
+            if (params?.query && url !== undefined) {
                 Object.entries(params.query).forEach(([key, value]) => {
                     (url as URL).searchParams.append(key, String(value));
                 });


### PR DESCRIPTION
# Description

Query parameters are appended twice to url, fixes that.

Fixes #2652

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] No need test

**Test Configuration**:
* Node.js Version: Any
* Yarn Version: Any

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated redundant logic for appending HTTP query parameters to requests, reducing duplication while preserving existing behavior, headers, body handling, and error responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->