### PR TITLE
feat: vip191 tx request

### DIFF
--- a/examples/thor/dappkit-example/README.md
+++ b/examples/thor/dappkit-example/README.md
@@ -12,6 +12,8 @@ yarn dev
 
 * Creating a TransactionRequest using this version of the SDK
 * Adapting the TransactionRequest to a format that can be sent to dapp-kit for signing
+* Sending a undelegated transaction to VeWorld chrome extension
+* Sending a fee delegated transaction to VeWorld chrome extension
 
 ## Technical Notes
 

--- a/examples/thor/dappkit-example/index.ts
+++ b/examples/thor/dappkit-example/index.ts
@@ -118,7 +118,6 @@ const toTransactionRequestInput = (request: TransactionRequest): TransactionRequ
         data: clause.data ?? '0x',
       })),
     };
-    console.log('input', input);
     return input;
 };
 

--- a/examples/thor/dappkit-example/index.ts
+++ b/examples/thor/dappkit-example/index.ts
@@ -1,7 +1,8 @@
 import { DAppKitUI, friendlyAddress } from '@vechain/dapp-kit-ui';
-import { Address, Revision } from '@vechain/sdk-temp/common';
+import { Address } from '@vechain/sdk-temp/common';
 import { ClauseBuilder, ThorClient, ThorNetworks, TransactionBuilder, TransactionRequest } from '@vechain/sdk-temp/thor';
 import type { TransactionRequestInput } from '@vechain/sdk-network';
+import type { TransactionMessage } from '@vechain/dapp-kit';
 
 // Inject the demo card layout directly into the #app container.
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
@@ -14,7 +15,8 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
         <div class="label">Custom button</div>
         <button class="cta" id="custom-button">Connect Custom Button</button>
         <div class="label">Transaction</div>
-        <button class="secondary" id="send-tx">Send Transaction</button>
+        <button class="secondary" id="send-tx">Send UnDelegated Transaction</button>
+        <button class="secondary" id="send-tx-with-fee-delegation">Send Transaction with Fee Delegation</button>
         <div class="label">Typed data</div>
         <button class="secondary" id="sign-typed-data-button">Sign Typed Data</button>
     </div>
@@ -75,15 +77,23 @@ if (customButton) {
 
 // Create a transaction request for a simple VET transfer
 // No need to estimate gas, it will be done by veworld wallet when sending the transaction
-async function createTransactionRequest(): Promise<TransactionRequest> {
+async function createTransactionRequest(isDelegated: boolean = false): Promise<TransactionRequest> {
     const thorClient = ThorClient.at(ThorNetworks.TESTNET);
     const builder = TransactionBuilder.create(thorClient);
     const clauses = ClauseBuilder.transferVET(Address.of('0xf077b491b355E64048cE21E3A6Fc4751eEeA77fa'), 1n);
-    const txRequest = await builder
+    if (!isDelegated) {
+        return await builder
+            .withClauses([clauses])
+            .withDynFeeTxDefaults()
+            .build();
+    }
+    // return a delegated transaction request
+    return await builder
         .withClauses([clauses])
         .withDynFeeTxDefaults()
+        .withDelegatedFee()
+        .withFeeDelegationUrl('https://sponsor-testnet.vechain.energy/by/883')
         .build();
-    return txRequest;
 }
 
 // Converts a TransactionRequest to a TransactionRequestInput for dappkit compatibility
@@ -91,7 +101,7 @@ const toTransactionRequestInput = (request: TransactionRequest): TransactionRequ
     // convert to primitive types
     const json = request.toJSON();
     // return a TransactionRequestInput
-    return {
+    const input = {
       chainTag: json.chainTag,
       blockRef: json.blockRef,
       expiration: json.expiration,
@@ -101,15 +111,29 @@ const toTransactionRequestInput = (request: TransactionRequest): TransactionRequ
       maxPriorityFeePerGas: json.maxPriorityFeePerGas?.toString(),
       nonce: json.nonce,
       dependsOn: json.dependsOn ?? undefined,
+      delegationUrl: request.feeDelegationUrl?.toString() ?? undefined,
       clauses: json.clauses.map((clause) => ({
         to: clause.to,
         value: clause.value,
         data: clause.data ?? '0x',
       })),
     };
+    console.log('input', input);
+    return input;
 };
 
-// Button that triggers a simple VET transfer.
+// Converts a TransactionRequest to a TransactionMessage[] for dappkit compatibility
+const toTransactionMessage = (request: TransactionRequest): TransactionMessage[] => {
+    return request.clauses.map((clause) => ({
+        to: clause.to?.toString() ?? '',
+        value: clause.value.toString(),
+        data: clause.data?.toString() ?? undefined,
+        comment: clause.comment ?? undefined,
+    } satisfies TransactionMessage));
+};
+
+// Button that triggers a simple VET transfer (undelegated).
+// This uses the sendTransaction function which requires a TransactionRequestInput
 const sendTxButton = document.getElementById('send-tx');
 if (sendTxButton) {
     sendTxButton.addEventListener('click', async () => {
@@ -118,6 +142,15 @@ if (sendTxButton) {
     });
 }
 
+// Button that triggers a simple VET transfer (delegated).
+// This uses the signTx function which requires a TransactionMessage[] and TransactionOptions
+const sendTxWithFeeDelegationButton = document.getElementById('send-tx-with-fee-delegation');
+if (sendTxWithFeeDelegationButton) {
+    sendTxWithFeeDelegationButton.addEventListener('click', async () => {
+        const txRequest = await createTransactionRequest(true);
+        DAppKitUI.wallet.signTx(toTransactionMessage(txRequest), {delegator: {url: 'https://sponsor-testnet.vechain.energy/by/883'}});
+    });
+}
 // Button that asks the wallet to sign typed data payload.
 const signTypedDataButton = document.getElementById('sign-typed-data-button');
 if (signTypedDataButton) {

--- a/examples/thor/generic-delegator-tx/index.ts
+++ b/examples/thor/generic-delegator-tx/index.ts
@@ -94,7 +94,7 @@ async function main(): Promise<void> {
     combinedSignature.set(delegatorSig, originSig.length);
 
     // Create fully signed transaction using delegator's transaction body
-    const fullySigned = TransactionRequest.of(delegatorTx, combinedSignature);
+    const fullySigned = TransactionRequest.of(delegatorTx, { signature: combinedSignature });
     const txId = await thorClient.transactions.sendTransaction(fullySigned);
     console.log('Transaction id:', txId.toString());
 

--- a/examples/thor/write-contracts-delegation/index.ts
+++ b/examples/thor/write-contracts-delegation/index.ts
@@ -81,7 +81,7 @@ if (sponsorResponse.ok) {
     combinedSignature.set(sponsorSig, senderSig.length);
 
     // Create fully signed transaction
-    const fullySigned = TransactionRequest.of(txRequest, combinedSignature);
+    const fullySigned = TransactionRequest.of(txRequest, { signature: combinedSignature });
     const txId = await thorClient.transactions.sendTransaction(fullySigned);
     console.log('Transaction id:', txId.toString());
 } else {

--- a/examples/viem/generic-delegator-tx/index.ts
+++ b/examples/viem/generic-delegator-tx/index.ts
@@ -96,7 +96,7 @@ async function main(): Promise<void> {
     combinedSignature.set(originSig, 0);
     combinedSignature.set(delegatorSig, originSig.length);
 
-    const fullySigned = TransactionRequest.of(delegatorTx, combinedSignature);
+    const fullySigned = TransactionRequest.of(delegatorTx, { signature: combinedSignature });
 
     const txId = await walletClient.sendRawTransaction(fullySigned.encoded);
     console.log('Transaction id:', txId.toString());

--- a/examples/viem/write-contracts-delegation/index.ts
+++ b/examples/viem/write-contracts-delegation/index.ts
@@ -76,7 +76,7 @@ if (sponsorResponse.ok) {
     combinedSignature.set(senderSig, 0);
     combinedSignature.set(sponsorSig, senderSig.length);
 
-    const fullySigned = TransactionRequest.of(txRequest, combinedSignature);
+    const fullySigned = TransactionRequest.of(txRequest, { signature: combinedSignature });
     const txId = await walletClient.sendTransaction(fullySigned);
     console.log('Transaction id:', txId.toString());
 

--- a/packages/sdk/src/common/http/FetchHttpClient.ts
+++ b/packages/sdk/src/common/http/FetchHttpClient.ts
@@ -69,7 +69,7 @@ class FetchHttpClient implements HttpClient {
         httpOptions: HttpOptions = {},
         // Default dependencies to global objects, allows for testing injection or custom implementations
         requestConstructor: RequestConstructor = Request,
-        fetchFunction: FetchFunction = fetch
+        fetchFunction: FetchFunction = globalThis.fetch.bind(globalThis)
     ) {
         if (!baseURL.pathname.endsWith(FetchHttpClient.PATH_SEPARATOR)) {
             baseURL.pathname += FetchHttpClient.PATH_SEPARATOR;

--- a/packages/sdk/src/thor/signer/PrivateKeySigner.ts
+++ b/packages/sdk/src/thor/signer/PrivateKeySigner.ts
@@ -181,7 +181,7 @@ class PrivateKeySigner extends Signer {
                 )
             ).bytes;
         } else {
-            // sign transaction request as using the private key
+            // sign transaction request using the private key
             if (this.#privateKey !== null) {
                 const senderHash = Blake2b256.of(
                     concatBytes(

--- a/packages/sdk/src/thor/signer/PrivateKeySigner.ts
+++ b/packages/sdk/src/thor/signer/PrivateKeySigner.ts
@@ -164,7 +164,7 @@ class PrivateKeySigner extends Signer {
         // hold signature bytes
         let gasPayerSignature: Uint8Array | null = null;
         // check for VIP-191
-        // if transaction request has feel delegation url on it, use it
+        // if transaction request has fee delegation url on it, use it
         if (transactionRequest.feeDelegationUrl !== undefined) {
             const vip191Client = VIP191Client.of(
                 transactionRequest.feeDelegationUrl.toString()

--- a/packages/sdk/src/thor/signer/PrivateKeySigner.ts
+++ b/packages/sdk/src/thor/signer/PrivateKeySigner.ts
@@ -163,9 +163,17 @@ class PrivateKeySigner extends Signer {
         }
         // hold signature bytes
         let gasPayerSignature: Uint8Array | null = null;
-        // check if to get signature via VIP-191 client
-        if (this.isVIP191Supported && this.vip191Client !== undefined) {
-            // use VIP-191 client to sign transaction request as gas payer
+        // check for VIP-191
+        // if transaction request has feel delegation url on it, use it
+        if (transactionRequest.feeDelegationUrl !== undefined) {
+            const vip191Client = VIP191Client.of(
+                transactionRequest.feeDelegationUrl.toString()
+            );
+            gasPayerSignature = (
+                await vip191Client.requestSignature(sender, transactionRequest)
+            ).bytes;
+        } else if (this.isVIP191Supported && this.vip191Client !== undefined) {
+            // if this signer supports VIP-191, use it
             gasPayerSignature = (
                 await this.vip191Client.requestSignature(
                     sender,
@@ -173,7 +181,7 @@ class PrivateKeySigner extends Signer {
                 )
             ).bytes;
         } else {
-            // sign transaction request as gas payer using the private key
+            // sign transaction request as using the private key
             if (this.#privateKey !== null) {
                 const senderHash = Blake2b256.of(
                     concatBytes(
@@ -203,18 +211,22 @@ class PrivateKeySigner extends Signer {
             if (transactionRequest.signature !== undefined) {
                 return TransactionRequest.of(
                     { ...transactionRequest },
-                    concatBytes(
-                        transactionRequest.signature.slice(
-                            0,
-                            Secp256k1.SIGNATURE_LENGTH
-                        ),
-                        gasPayerSignature
-                    )
+                    {
+                        signature: concatBytes(
+                            transactionRequest.signature.slice(
+                                0,
+                                Secp256k1.SIGNATURE_LENGTH
+                            ),
+                            gasPayerSignature
+                        )
+                    }
                 );
             } else {
                 return TransactionRequest.of(
                     { ...transactionRequest },
-                    gasPayerSignature
+                    {
+                        signature: gasPayerSignature
+                    }
                 );
             }
         } else {
@@ -250,17 +262,21 @@ class PrivateKeySigner extends Signer {
                 if (transactionRequest.signature !== undefined) {
                     return TransactionRequest.of(
                         { ...transactionRequest },
-                        concatBytes(
-                            originSignature,
-                            transactionRequest.signature.slice(
-                                Secp256k1.SIGNATURE_LENGTH
+                        {
+                            signature: concatBytes(
+                                originSignature,
+                                transactionRequest.signature.slice(
+                                    Secp256k1.SIGNATURE_LENGTH
+                                )
                             )
-                        )
+                        }
                     );
                 } else {
                     return TransactionRequest.of(
                         { ...transactionRequest },
-                        originSignature
+                        {
+                            signature: originSignature
+                        }
                     );
                 }
             }
@@ -290,7 +306,12 @@ class PrivateKeySigner extends Signer {
         if (this.#privateKey !== null) {
             return TransactionRequest.of(
                 { ...transactionRequest },
-                Secp256k1.sign(transactionRequest.hash.bytes, this.#privateKey)
+                {
+                    signature: Secp256k1.sign(
+                        transactionRequest.hash.bytes,
+                        this.#privateKey
+                    )
+                }
             );
         }
         log.error({

--- a/packages/sdk/src/thor/thor-client/model/transactions/TransactionBody.ts
+++ b/packages/sdk/src/thor/thor-client/model/transactions/TransactionBody.ts
@@ -120,6 +120,11 @@ interface TransactionBodyOptions {
     isDelegated?: boolean;
 
     /**
+     * The URL of the fee delegation service.
+     */
+    feeDelegationUrl?: string;
+
+    /**
      * Nonce value for various purposes.
      * Basic is to prevent replay attack by make transaction unique.
      * Every transaction with same chainTag, blockRef, ... must have different nonce.

--- a/packages/sdk/src/thor/thor-client/model/transactions/TransactionRequest.ts
+++ b/packages/sdk/src/thor/thor-client/model/transactions/TransactionRequest.ts
@@ -12,6 +12,20 @@ import { BaseTransaction, type TransactionBody } from './BaseTransaction';
 import { PrivateKeySigner } from '@thor/signer';
 
 /**
+ * Options for the transaction request.
+ */
+interface TransactionRequestOptions {
+    /**
+     * The transaction signature.
+     */
+    signature?: Uint8Array;
+    /**
+     * The URL of the fee delegation service.
+     */
+    feeDelegationUrl?: string;
+}
+
+/**
  * Represents a transaction request to **Thor** blockchain system.
  * Encapsulates all information required to process and execute a transaction.
  */
@@ -22,19 +36,42 @@ class TransactionRequest extends BaseTransaction {
     public readonly signature?: Uint8Array;
 
     /**
+     * The URL of the fee delegation service.
+     */
+    public readonly feeDelegationUrl?: URL;
+
+    /**
      * Constructs a new instance of the class with the provided parameters.
      *
      * @param {TransactionBody} body - The transaction request parameters.
-     * @param {Uint8Array} [signature] - Optional overall transaction signature
+     * @param {TransactionRequestOptions} options - The options for the transaction request.
      */
-    protected constructor(body: TransactionBody, signature?: Uint8Array) {
+    protected constructor(
+        body: TransactionBody,
+        options?: TransactionRequestOptions
+    ) {
         super(body);
         if (
             TransactionRequest.isLegacy(body) ||
             TransactionRequest.isDynamicFee(body)
         ) {
             this.signature =
-                signature !== undefined ? new Uint8Array(signature) : undefined;
+                options?.signature !== undefined
+                    ? new Uint8Array(options.signature)
+                    : undefined;
+            this.feeDelegationUrl =
+                options?.feeDelegationUrl !== undefined
+                    ? new URL(options.feeDelegationUrl)
+                    : undefined;
+            if (!this.isDelegated) {
+                if (this.feeDelegationUrl !== undefined) {
+                    throw new InvalidTransactionField(
+                        'TransactionRequest.constructor',
+                        'Fee delegation URL is not allowed for non-delegated transactions',
+                        { body }
+                    );
+                }
+            }
         } else {
             throw new InvalidTransactionField(
                 'TransactionRequest.constructor',
@@ -48,14 +85,14 @@ class TransactionRequest extends BaseTransaction {
      * Creates a new instance of the class with the provided parameters.
      *
      * @param {TransactionBody} body - The transaction request parameters.
-     * @param {Uint8Array} [signature] - Optional overall transaction signature
+     * @param {TransactionRequestOptions} options - The options for the transaction request.
      * @return {TransactionRequest} A new instance of the class.
      */
     public static of(
         body: TransactionBody,
-        signature?: Uint8Array
+        options?: TransactionRequestOptions
     ): TransactionRequest {
-        return new TransactionRequest(body, signature);
+        return new TransactionRequest(body, options);
     }
 
     /**
@@ -205,4 +242,4 @@ class TransactionRequest extends BaseTransaction {
     }
 }
 
-export { TransactionRequest };
+export { TransactionRequest, type TransactionRequestOptions };

--- a/packages/sdk/src/thor/thor-client/rlp/TransactionRequestRLPCodec.ts
+++ b/packages/sdk/src/thor/thor-client/rlp/TransactionRequestRLPCodec.ts
@@ -341,7 +341,9 @@ class TransactionRequestRLPCodec {
                     : undefined
         } satisfies TransactionBody;
         // Create and return TransactionRequest with signatures.
-        return TransactionRequest.of(params, body.signature);
+        return TransactionRequest.of(params, {
+            signature: body.signature
+        });
     }
 
     /**

--- a/packages/sdk/src/thor/thor-client/transactions/TransactionBuilder.ts
+++ b/packages/sdk/src/thor/thor-client/transactions/TransactionBuilder.ts
@@ -4,12 +4,14 @@ import {
     type AddressLike,
     BlockRef,
     Hex,
+    HexUInt,
     Revision
 } from '@common/vcdm';
 import { type EstimateGasOptions, type ThorClient } from '@thor/thor-client';
 import {
     type Clause,
-    TransactionRequest
+    TransactionRequest,
+    TransactionRequestOptions
 } from '@thor/thor-client/model/transactions';
 import { type TransactionBody } from '@thor/thor-client/model/transactions/BaseTransaction';
 import { RetrieveRegularBlock } from '@thor/thorest/blocks';
@@ -39,6 +41,7 @@ interface AsyncBuildTask {
  */
 class TransactionBuilder {
     private params: TransactionBody;
+    private options: TransactionRequestOptions;
     private buildTasks: AsyncBuildTask[];
 
     private readonly thorClient: ThorClient;
@@ -49,7 +52,7 @@ class TransactionBuilder {
     private static readonly STARTING_NONCE = 0n;
     private static readonly STARTING_GAS = 0n;
 
-    // starting values for the builder
+    // starting values for the transaction body
     private readonly startingParams: TransactionBody = {
         blockRef: TransactionBuilder.STARTING_BLOCK_REF,
         chainTag: TransactionBuilder.STARTING_CHAIN_TAG,
@@ -64,10 +67,17 @@ class TransactionBuilder {
         reserved: undefined
     } satisfies TransactionBody;
 
+    // starting values for the transaction request options
+    private readonly startingOptions: TransactionRequestOptions = {
+        signature: undefined,
+        feeDelegationUrl: undefined
+    };
+
     // constructor from thor client
     private constructor(thorClient: ThorClient) {
         this.thorClient = thorClient;
         this.params = { ...this.startingParams, clauses: [] };
+        this.options = { ...this.startingOptions };
         this.buildTasks = [];
         log.debug({
             message: 'TransactionBuilder created',
@@ -323,6 +333,34 @@ class TransactionBuilder {
     }
 
     /**
+     * Sets the signature for the transaction.
+     * @param signature - The signature to set.
+     * @returns The builder instance.
+     */
+    public withSignature(signature: Uint8Array): this {
+        this.options.signature = signature;
+        log.debug({
+            message: 'TransactionBuilder.withSignature',
+            context: { signature: HexUInt.of(signature).toString() }
+        });
+        return this;
+    }
+
+    /**
+     * Sets the fee delegation URL for the transaction.
+     * @param feeDelegationUrl - The fee delegation URL to set.
+     * @returns The builder instance.
+     */
+    public withFeeDelegationUrl(feeDelegationUrl: string): this {
+        this.options.feeDelegationUrl = feeDelegationUrl;
+        log.debug({
+            message: 'TransactionBuilder.withFeeDelegationUrl',
+            context: { feeDelegationUrl }
+        });
+        return this;
+    }
+
+    /**
      * Sets the default block ref for the transaction to the current best block.
      * @returns The builder instance.
      */
@@ -471,11 +509,12 @@ class TransactionBuilder {
     }
 
     /**
-     * Resets the builder, erasing all the set parameters.
+     * Resets the builder, erasing all the set parameters and options.
      * @returns The builder instance.
      */
     public reset(): this {
         this.params = { ...this.startingParams, clauses: [] };
+        this.options = { ...this.startingOptions };
         this.buildTasks = [];
         log.debug({
             message: 'TransactionBuilder reset'
@@ -585,7 +624,7 @@ class TransactionBuilder {
             // check if the transaction request can be built after running all async tasks
             await this.postBuildChecks();
             // build the transaction request
-            return TransactionRequest.of(this.params);
+            return TransactionRequest.of(this.params, this.options);
         } finally {
             this.reset();
         }

--- a/packages/sdk/src/thor/thor-client/transactions/transactions-module.ts
+++ b/packages/sdk/src/thor/thor-client/transactions/transactions-module.ts
@@ -291,6 +291,10 @@ class TransactionsModule extends AbstractThorModule {
             ) {
                 txBuilder.withDefaultMaxFeePerGas();
             }
+            // fee delegation url
+            if (options?.feeDelegationUrl !== undefined) {
+                txBuilder.withFeeDelegationUrl(options.feeDelegationUrl);
+            }
             // build the transaction request
             return await txBuilder.build();
         } catch (error) {

--- a/packages/sdk/tests/thor/signer/PrivateKeySignerVIP191.testnet.test.ts
+++ b/packages/sdk/tests/thor/signer/PrivateKeySignerVIP191.testnet.test.ts
@@ -5,7 +5,8 @@ import { PrivateKeySigner } from '@thor/signer';
 import {
     ClauseBuilder,
     ThorClient,
-    TransactionBuilder
+    TransactionBuilder,
+    TransactionRequest
 } from '@thor/thor-client';
 import { ThorNetworks } from '@thor/utils';
 
@@ -73,5 +74,49 @@ describe('PrivateKeySigner VIP191 Testnet Tests', () => {
         expect(fullySignedGasPayerSignature).not.toEqual(
             senderSignedTxRequest.signature
         );
+    });
+    test('ok <- signer will use the vip191 service url on the transaction request', async () => {
+        const thorClient = ThorClient.at(ThorNetworks.TESTNET);
+        // create tx request with a VET transfer clause and a fee delegation url
+        const clause = ClauseBuilder.transferVET(receiverAddress, 1n);
+        const txRequest = await TransactionBuilder.create(thorClient)
+            .withClauses([clause])
+            .withEstimatedGas(senderAddress, { revision: Revision.BEST })
+            .withDynFeeTxDefaults()
+            .withDelegatedFee()
+            .withFeeDelegationUrl(
+                'https://sponsor-testnet.vechain.energy/by/883'
+            )
+            .build();
+        // create a private key signer without a vip191 service url
+        const signer = new PrivateKeySigner(HexUInt.of(senderPrivateKey).bytes);
+        // sign the transaction as sender
+        const senderSignedTxRequest = await signer.sign(txRequest);
+        // sign the transaction using vechain energy as gas payer
+        const vechainEnergySignedTxRequest = await signer.sign(
+            senderSignedTxRequest,
+            senderAddress
+        );
+        // remove the fee delegation url from the transaction request
+        const txRequestWithoutFeeDelegationUrl = TransactionRequest.of(
+            { ...txRequest },
+            {
+                feeDelegationUrl: undefined,
+                signature: senderSignedTxRequest.signature
+            }
+        );
+        // sign the transaction using now just the private key as gas payer
+        const privateKeySignedTxRequest = await signer.sign(
+            txRequestWithoutFeeDelegationUrl
+        );
+        // check the vechain energy signature is different from the private key signature
+        const vechainEnergySignature =
+            vechainEnergySignedTxRequest.signature?.slice(
+                Secp256k1.SIGNATURE_LENGTH
+            );
+        const privateKeySignature = privateKeySignedTxRequest.signature?.slice(
+            Secp256k1.SIGNATURE_LENGTH
+        );
+        expect(vechainEnergySignature).not.toEqual(privateKeySignature);
     });
 });

--- a/packages/sdk/tests/thor/thor-client/transactions/BuildTransactionBody.unit.test.ts
+++ b/packages/sdk/tests/thor/thor-client/transactions/BuildTransactionBody.unit.test.ts
@@ -1,3 +1,4 @@
+import { InvalidTransactionField } from '@common/errors';
 import { IllegalArgumentError } from '@common/errors/IllegalArgumentError';
 import { Address, Hex } from '@common/vcdm';
 import { describe, expect, test } from '@jest/globals';
@@ -107,5 +108,48 @@ describe('BuildTransactionBody UNIT tests', () => {
             bodyOptions
         );
         await expect(txRequest).rejects.toThrow(IllegalArgumentError);
+    });
+    test('should be able to build a transaction request with a fee delegation url', async () => {
+        const thorClient = ThorClient.at('http://localhost:8669');
+        const clauses = [new Clause(Address.of('0x0'), 1n, null, null, null)];
+        const bodyOptions: TransactionBodyOptions = {
+            blockRef: Hex.of('0x1234'),
+            chainTag: 1,
+            expiration: 1,
+            maxFeePerGas: 100000n,
+            maxPriorityFeePerGas: 100000n,
+            nonce: 9n,
+            isDelegated: true,
+            feeDelegationUrl: 'https://sponsor-testnet.vechain.energy/by/883'
+        };
+        const txRequest = await thorClient.transactions.buildTransactionBody(
+            clauses,
+            100000,
+            bodyOptions
+        );
+        expect(txRequest).toBeDefined();
+        expect(txRequest.feeDelegationUrl?.toString()).toBe(
+            'https://sponsor-testnet.vechain.energy/by/883'
+        );
+    });
+    test('should throw an error if a fee delegation url is provided for a non-delegated transaction', async () => {
+        const thorClient = ThorClient.at('http://localhost:8669');
+        const clauses = [new Clause(Address.of('0x0'), 1n, null, null, null)];
+        const bodyOptions: TransactionBodyOptions = {
+            blockRef: Hex.of('0x1234'),
+            chainTag: 1,
+            expiration: 1,
+            maxFeePerGas: 100000n,
+            maxPriorityFeePerGas: 100000n,
+            nonce: 9n,
+            isDelegated: false,
+            feeDelegationUrl: 'https://sponsor-testnet.vechain.energy/by/883'
+        };
+        const txRequest = thorClient.transactions.buildTransactionBody(
+            clauses,
+            100000,
+            bodyOptions
+        );
+        await expect(txRequest).rejects.toThrow(InvalidTransactionField);
     });
 });

--- a/packages/sdk/tests/thor/thor-client/transactions/TransactionBuilder.solo.test.ts
+++ b/packages/sdk/tests/thor/thor-client/transactions/TransactionBuilder.solo.test.ts
@@ -104,4 +104,35 @@ describe('TransactionBuilder SOLO tests', () => {
         const txRequest = await builder.build();
         expect(txRequest.gas).toBe(0n);
     });
+    test('create delegated transaction with fee delegation url', async () => {
+        const builder = TransactionBuilder.create(thorClient);
+        const transaction = await builder
+            .withClauses(clauses)
+            .withEstimatedGas(sender, {
+                revision: Revision.BEST
+            })
+            .withDelegatedFee()
+            .withFeeDelegationUrl(
+                'https://sponsor-testnet.vechain.energy/by/883'
+            )
+            .build();
+        expect(transaction.feeDelegationUrl?.toString()).toBe(
+            'https://sponsor-testnet.vechain.energy/by/883'
+        );
+        expect(transaction.isDelegated).toBe(true);
+    });
+    test('should throw an error if a fee delegation url is provided for a non-delegated transaction', async () => {
+        const builder = TransactionBuilder.create(thorClient);
+        await expect(() =>
+            builder
+                .withClauses(clauses)
+                .withEstimatedGas(sender, {
+                    revision: Revision.BEST
+                })
+                .withFeeDelegationUrl(
+                    'https://sponsor-testnet.vechain.energy/by/883'
+                )
+                .build()
+        ).rejects.toThrow(InvalidTransactionField);
+    });
 });

--- a/packages/sdk/tests/thor/thor-client/transactions/TransactionRequest.unit.test.ts
+++ b/packages/sdk/tests/thor/thor-client/transactions/TransactionRequest.unit.test.ts
@@ -73,7 +73,9 @@ describe('TransactionRequest', () => {
                 maxPriorityFeePerGas: mockMaxPriorityFeePerGas
             };
 
-            const transaction = TransactionRequest.of(params, mockSignature);
+            const transaction = TransactionRequest.of(params, {
+                signature: mockSignature
+            });
 
             expect(transaction.blockRef).toBe(mockBlockRef);
             expect(transaction.chainTag).toBe(1);
@@ -103,7 +105,9 @@ describe('TransactionRequest', () => {
                 nonce: mockNonce
             };
 
-            const transaction = TransactionRequest.of(params, mockSignature);
+            const transaction = TransactionRequest.of(params, {
+                signature: mockSignature
+            });
 
             expect(transaction.blockRef).toBe(mockBlockRef);
             expect(transaction.chainTag).toBe(1);
@@ -131,7 +135,9 @@ describe('TransactionRequest', () => {
             };
             const originalSig = new Uint8Array([7, 8, 9]);
 
-            const transaction = TransactionRequest.of(params, originalSig);
+            const transaction = TransactionRequest.of(params, {
+                signature: originalSig
+            });
 
             // Modify original arrays
             originalSig[0] = 99;
@@ -279,10 +285,9 @@ describe('TransactionRequest', () => {
                 nonce: mockNonce
             };
 
-            const transaction = TransactionRequest.of(
-                params,
-                mockOriginSignature
-            );
+            const transaction = TransactionRequest.of(params, {
+                signature: mockOriginSignature
+            });
             expect(transaction.isSigned).toBe(true);
         });
 
@@ -304,10 +309,9 @@ describe('TransactionRequest', () => {
             };
 
             // Only origin signature
-            const transaction1 = TransactionRequest.of(
-                params,
-                mockOriginSignature
-            );
+            const transaction1 = TransactionRequest.of(params, {
+                signature: mockOriginSignature
+            });
             expect(transaction1.isSigned).toBe(false);
         });
 
@@ -331,7 +335,9 @@ describe('TransactionRequest', () => {
                 ...mockOriginSignature,
                 ...mockGasPayerSignature
             ]);
-            const transaction = TransactionRequest.of(params, fullSignature);
+            const transaction = TransactionRequest.of(params, {
+                signature: fullSignature
+            });
             expect(transaction.isSigned).toBe(true);
         });
 
@@ -348,7 +354,9 @@ describe('TransactionRequest', () => {
             };
 
             const wrongSignature = new Uint8Array([1, 2, 3]); // Different length
-            const transaction = TransactionRequest.of(params, wrongSignature);
+            const transaction = TransactionRequest.of(params, {
+                signature: wrongSignature
+            });
             expect(transaction.isSigned).toBe(false);
         });
 
@@ -370,7 +378,9 @@ describe('TransactionRequest', () => {
             };
 
             const wrongSignature = new Uint8Array([1, 2, 3]); // Different length
-            const transaction = TransactionRequest.of(params, wrongSignature);
+            const transaction = TransactionRequest.of(params, {
+                signature: wrongSignature
+            });
             expect(transaction.isSigned).toBe(false);
         });
     });
@@ -421,7 +431,9 @@ describe('TransactionRequest', () => {
                 }
             };
 
-            const transaction = TransactionRequest.of(params, mockSignature);
+            const transaction = TransactionRequest.of(params, {
+                signature: mockSignature
+            });
             const json = transaction.toJSON();
 
             expect(json.blockRef).toBe(mockBlockRef.toString());
@@ -452,7 +464,9 @@ describe('TransactionRequest', () => {
                 }
             };
 
-            const transaction = TransactionRequest.of(params, mockSignature);
+            const transaction = TransactionRequest.of(params, {
+                signature: mockSignature
+            });
             const json = transaction.toJSON();
 
             expect(json.blockRef).toBe(mockBlockRef.toString());

--- a/packages/sdk/tests/thor/thorest/transactions/TransactionRequest.unit.test.ts
+++ b/packages/sdk/tests/thor/thorest/transactions/TransactionRequest.unit.test.ts
@@ -66,7 +66,9 @@ describe('TransactionRequest UNIT tests', () => {
             } satisfies TransactionBody;
 
             const originSig = new Uint8Array([1, 2, 3]);
-            const txRequest = TransactionRequest.of(body, originSig);
+            const txRequest = TransactionRequest.of(body, {
+                signature: originSig
+            });
             expect(txRequest.blockRef).toBe(body.blockRef);
             expect(txRequest.chainTag).toBe(body.chainTag);
             expect(txRequest.clauses).toEqual(body.clauses);
@@ -106,7 +108,9 @@ describe('TransactionRequest UNIT tests', () => {
             } satisfies TransactionBody;
 
             const originSig = new Uint8Array([1, 2, 3]);
-            const txRequest = TransactionRequest.of(body, originSig);
+            const txRequest = TransactionRequest.of(body, {
+                signature: originSig
+            });
             expect(txRequest.blockRef).toBe(body.blockRef);
             expect(txRequest.chainTag).toBe(body.chainTag);
             expect(txRequest.clauses).toEqual(body.clauses);
@@ -450,6 +454,75 @@ describe('TransactionRequest UNIT tests', () => {
                 expect(invalidFieldError.args).toBeDefined();
             }
         });
+        test('ok <- constructor with fee delegation url for delegated transaction', () => {
+            const params = {
+                blockRef: mockBlockRef,
+                chainTag: mockChainTag,
+                clauses: [],
+                dependsOn: null,
+                expiration: mockExpiration,
+                gas: mockGas,
+                gasPriceCoef: undefined,
+                maxFeePerGas: 1n,
+                maxPriorityFeePerGas: 0n,
+                nonce: mockNonce,
+                reserved: {
+                    features: 1,
+                    unused: []
+                }
+            } satisfies TransactionBody;
+            const txRequest = TransactionRequest.of(params, {
+                feeDelegationUrl:
+                    'https://sponsor-testnet.vechain.energy/by/883'
+            });
+            expect(txRequest.feeDelegationUrl?.toString()).toBe(
+                'https://sponsor-testnet.vechain.energy/by/883'
+            );
+        });
+        test('ok <- constructor with no fee delegation url for delegated transaction', () => {
+            const params = {
+                blockRef: mockBlockRef,
+                chainTag: mockChainTag,
+                clauses: [],
+                dependsOn: null,
+                expiration: mockExpiration,
+                gas: mockGas,
+                gasPriceCoef: undefined,
+                maxFeePerGas: 1n,
+                maxPriorityFeePerGas: 0n,
+                nonce: mockNonce,
+                reserved: {
+                    features: 1,
+                    unused: []
+                }
+            } satisfies TransactionBody;
+            const txRequest = TransactionRequest.of(params);
+            expect(txRequest.feeDelegationUrl).toBeUndefined();
+        });
+        test('err <- throws InvalidTransactionField for fee delegation url for non-delegated transaction', () => {
+            const params = {
+                blockRef: mockBlockRef,
+                chainTag: mockChainTag,
+                clauses: [],
+                dependsOn: null,
+                expiration: mockExpiration,
+                gas: mockGas,
+                gasPriceCoef: undefined,
+                maxFeePerGas: 1n,
+                maxPriorityFeePerGas: 0n,
+                nonce: mockNonce,
+                reserved: {
+                    features: 0,
+                    unused: []
+                }
+            } satisfies TransactionBody;
+            expect(() => {
+                TransactionRequest.of(params, {
+                    feeDelegationUrl:
+                        'https://sponsor-testnet.vechain.energy/by/883'
+                });
+            }).toThrow(InvalidTransactionField);
+        });
     });
 
     describe('defensive copying of signature', () => {
@@ -466,7 +539,9 @@ describe('TransactionRequest UNIT tests', () => {
             };
 
             const originalSig = new Uint8Array([1, 2, 3]);
-            const txRequest = TransactionRequest.of(params, originalSig);
+            const txRequest = TransactionRequest.of(params, {
+                signature: originalSig
+            });
 
             // Modify original array
             originalSig[0] = 99;


### PR DESCRIPTION
# Description

For sending transaction in the FE of an app to VeWorld, this adds:

- feeDelegationUrl field to TransactionBodyOptions
- feeDelegationUrl field to TransactionRequest
- .withFeeDelegationURL method to TransactionBuilder

A fee delegation url can be set for a PrivateKeySigner, but this PR allows for that to be overridden by the url on the TransactionRequest also.

The dapp-kit example was updated to add a new button in its ui to send a delegation url to veworld chrome extension (Note: this PR in veworld fixes that: https://github.com/vechain/veworld-extension/pull/2979)

A small fix was done for FetchHttpClient for better browser compatibility. The issue was the "fetch" function was being directly references as a function. 

Fixes #2565 

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Local solo & unit tests
- [x] Tested the dappkit example on Chrome, Brave, Opera

**Test Configuration**:
* Node.js Version: v22
* Yarn Version: v4

# Checklist:

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] New and existing integration tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have not added any vulnerable dependencies to my code