### PR TITLE
Bump thor-devkit to 2.2.0, fix doc examples, and harden subscription polling

### DIFF
--- a/docs/examples/clauses/clause.ts
+++ b/docs/examples/clauses/clause.ts
@@ -40,7 +40,6 @@ const txBody = await thor.transactions.buildTransactionBody(
     gasResult.totalGas,
     {
         chainTag: chainTag,
-        blockRef: '0x0000000000000000',
         expiration: 32,
         gasPriceCoef: 128,
         dependsOn: null,

--- a/docs/examples/clauses/contractClause.ts
+++ b/docs/examples/clauses/contractClause.ts
@@ -62,7 +62,6 @@ const txBody = await thor.transactions.buildTransactionBody(
     gasResult.totalGas,
     {
         chainTag: chainTag,
-        blockRef: '0x0000000000000000',
         expiration: 32,
         gasPriceCoef: 128,
         dependsOn: null,

--- a/docs/examples/clauses/transactionClause.ts
+++ b/docs/examples/clauses/transactionClause.ts
@@ -52,7 +52,6 @@ const txBody = await thor.transactions.buildTransactionBody(
     gasResult.totalGas,
     {
         chainTag: chainTag,
-        blockRef: '0x0000000000000000',
         expiration: 32,
         gasPriceCoef: 128,
         dependsOn: null,

--- a/docs/examples/clauses/transactionClauseArray.ts
+++ b/docs/examples/clauses/transactionClauseArray.ts
@@ -52,7 +52,6 @@ const txBody = await thor.transactions.buildTransactionBody(
     gasResult.totalGas,
     {
         chainTag: chainTag,
-        blockRef: '0x0000000000000000',
         expiration: 32,
         gasPriceCoef: 128,
         dependsOn: null,

--- a/docs/examples/gas/fee-estimation.ts
+++ b/docs/examples/gas/fee-estimation.ts
@@ -58,7 +58,6 @@ const txBody = await thor.transactions.buildTransactionBody(
     gasResult.totalGas,
     {
         chainTag: chainTag,
-        blockRef: '0x0000000000000000',
         expiration: 32,
         gasPriceCoef: 128,
         dependsOn: null,

--- a/docs/examples/thor-client/contract.ts
+++ b/docs/examples/thor-client/contract.ts
@@ -75,5 +75,11 @@ const receipt = contract.deployTransactionReceipt;
 
 // END_SNIPPET: ContractSnippet
 
+expect(receipt).toBeDefined();
+
+if (receipt == null) {
+    throw new Error('Deployment receipt is unavailable');
+}
+
 expect(receipt.reverted).toEqual(false);
-expect(receipt.outputs[0].contractAddress).toBeDefined();
+expect(receipt.outputs[0]?.contractAddress).toBeDefined();

--- a/docs/galactica-hard-fork.md
+++ b/docs/galactica-hard-fork.md
@@ -211,7 +211,6 @@ const txBody = await thor.transactions.buildTransactionBody(
     gasResult.totalGas,
     {
         chainTag: chainTag,
-        blockRef: '0x0000000000000000',
         expiration: 32,
         gasPriceCoef: 128,
         dependsOn: null,

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "scripts": {
     "build": "find . -name \"*.md\" -type f -maxdepth 1 ! -name \"README.md\" -delete && tsup ./build-scripts && node dist/builddocs.cjs",
-    "test:examples": "ts-node-test examples/",
+    "test:examples": "node ./run-examples.mjs",
     "test:examples:solo": "(yarn start-thor-solo && yarn test:examples && yarn stop-thor-solo) || yarn stop-thor-solo"
   },
   "dependencies": {

--- a/docs/run-examples.mjs
+++ b/docs/run-examples.mjs
@@ -1,0 +1,97 @@
+import { spawn } from 'node:child_process';
+import { readdir } from 'node:fs/promises';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const docsDir = dirname(fileURLToPath(import.meta.url));
+const examplesDir = join(docsDir, 'examples');
+const tsNodeRegister = `data:text/javascript,${encodeURIComponent(
+    [
+        'import { register } from "node:module";',
+        'import { pathToFileURL } from "node:url";',
+        'register("ts-node/esm", pathToFileURL("./"));'
+    ].join('\n')
+)}`;
+
+const collectExampleFiles = async (directory) => {
+    const entries = await readdir(directory, { withFileTypes: true });
+    const files = await Promise.all(
+        entries
+            .sort((left, right) => left.name.localeCompare(right.name))
+            .map(async (entry) => {
+                const fullPath = join(directory, entry.name);
+
+                if (entry.isDirectory()) {
+                    return await collectExampleFiles(fullPath);
+                }
+
+                return entry.isFile() && entry.name.endsWith('.ts')
+                    ? [fullPath]
+                    : [];
+            })
+    );
+
+    return files.flat();
+};
+
+const runExample = async (file) =>
+    await new Promise((resolve) => {
+        const child = spawn(
+            process.execPath,
+            [
+                '--disable-warning=DEP0180',
+                '--import',
+                tsNodeRegister,
+                relative(docsDir, file)
+            ],
+            {
+                cwd: docsDir,
+                env: process.env,
+                stdio: 'inherit'
+            }
+        );
+
+        child.on('error', (error) => {
+            console.error(error);
+            resolve(1);
+        });
+
+        child.on('close', (code) => {
+            resolve(code ?? 1);
+        });
+    });
+
+const exampleFiles = await collectExampleFiles(examplesDir);
+
+if (exampleFiles.length === 0) {
+    console.error('No example files found.');
+    process.exit(1);
+}
+
+const failed = [];
+
+for (const file of exampleFiles) {
+    const startedAt = Date.now();
+    const exitCode = await runExample(file);
+    const durationMs = Date.now() - startedAt;
+    const displayPath = relative(docsDir, file);
+
+    if (exitCode === 0) {
+        console.log(`[PASS] ${displayPath} (${durationMs}ms)`);
+    } else {
+        console.error(`[FAIL] ${displayPath} (${durationMs}ms)`);
+        failed.push(displayPath);
+    }
+}
+
+console.log(`\nExamples: ${exampleFiles.length}`);
+console.log(`Passed: ${exampleFiles.length - failed.length}`);
+console.log(`Failed: ${failed.length}`);
+
+if (failed.length > 0) {
+    console.error('\nFailing examples:');
+    failed.forEach((file) => {
+        console.error(`- ${file}`);
+    });
+    process.exitCode = 1;
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "bignumber.js": "^9.1.2",
-    "thor-devkit": "^2.0.9",
+    "thor-devkit": "^2.2.0",
     "tsd": "^0.31.2"
   }
 }

--- a/packages/network/src/provider/providers/vechain-provider/vechain-provider.ts
+++ b/packages/network/src/provider/providers/vechain-provider/vechain-provider.ts
@@ -1,5 +1,6 @@
 import { HexInt } from '@vechain/sdk-core';
 import {
+    HttpNetworkError,
     JSONRPCMethodNotFound,
     JSONRPCMethodNotImplemented
 } from '@vechain/sdk-errors';
@@ -127,41 +128,52 @@ class VeChainProvider extends EventEmitter implements EIP1193ProviderMessage {
     public startSubscriptionsPolling(): boolean {
         let result = false;
         if (this.pollInstance === undefined) {
-            this.pollInstance = Poll.createEventPoll(async () => {
-                const data: SubscriptionEvent[] = [];
+            this.pollInstance = Poll.createEventPoll(
+                async () => {
+                    const data: SubscriptionEvent[] = [];
 
-                const currentBlock = await this.getCurrentBlock();
+                    const currentBlock = await this.getCurrentBlock();
 
-                if (currentBlock !== null) {
-                    if (
-                        this.subscriptionManager.newHeadsSubscription !==
-                        undefined
-                    ) {
-                        data.push({
-                            method: 'eth_subscription',
-                            params: {
-                                subscription:
-                                    this.subscriptionManager
-                                        .newHeadsSubscription.subscriptionId,
-                                result: currentBlock
-                            }
-                        });
+                    if (currentBlock !== null) {
+                        if (
+                            this.subscriptionManager.newHeadsSubscription !==
+                            undefined
+                        ) {
+                            data.push({
+                                method: 'eth_subscription',
+                                params: {
+                                    subscription:
+                                        this.subscriptionManager
+                                            .newHeadsSubscription
+                                            .subscriptionId,
+                                    result: currentBlock
+                                }
+                            });
+                        }
+                        if (
+                            this.subscriptionManager.logSubscriptions.size > 0
+                        ) {
+                            const logs = await this.getLogsRPC();
+                            data.push(...logs);
+                        }
+
+                        this.subscriptionManager.currentBlockNumber++;
                     }
-                    if (this.subscriptionManager.logSubscriptions.size > 0) {
-                        const logs = await this.getLogsRPC();
-                        data.push(...logs);
-                    }
-
-                    this.subscriptionManager.currentBlockNumber++;
-                }
-                return data;
-            }, POLLING_INTERVAL).onData(
-                (subscriptionEvents: SubscriptionEvent[]) => {
+                    return data;
+                },
+                POLLING_INTERVAL,
+                false
+            )
+                .onData((subscriptionEvents: SubscriptionEvent[]) => {
                     subscriptionEvents.forEach((event) => {
                         this.emit('message', event);
                     });
-                }
-            );
+                })
+                .onError((error) => {
+                    if (!(error instanceof HttpNetworkError)) {
+                        this.stopSubscriptionsPolling();
+                    }
+                });
 
             this.pollInstance.startListen();
             result = true;

--- a/packages/network/tests/thor-client/blocks/blocks.testnet.test.ts
+++ b/packages/network/tests/thor-client/blocks/blocks.testnet.test.ts
@@ -59,7 +59,7 @@ describe('ThorClient - Blocks Module', () => {
                 // Wait for all tests to complete
                 await Promise.all(tests);
             },
-            12000 * waitForBlockTestCases.length
+            30000 * waitForBlockTestCases.length
         );
     });
 
@@ -94,7 +94,7 @@ describe('ThorClient - Blocks Module', () => {
                 // Wait for all tests to complete
                 await Promise.all(tests);
             },
-            12000 * waitForBlockTestCases.length
+            30000 * waitForBlockTestCases.length
         );
     });
 

--- a/packages/network/tests/thor-client/blocks/fixture.ts
+++ b/packages/network/tests/thor-client/blocks/fixture.ts
@@ -13,7 +13,7 @@ const waitForBlockTestCases = [
     },
     {
         options: {
-            timeoutMs: 12000,
+            timeoutMs: 25000,
             intervalMs: undefined
         }
     },
@@ -25,7 +25,7 @@ const waitForBlockTestCases = [
     },
     {
         options: {
-            timeoutMs: 11000,
+            timeoutMs: 25000,
             intervalMs: 1000
         }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3919,7 +3919,7 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/node@^10.0.3", "@types/node@^10.3.2":
+"@types/node@^10.0.3":
   version "10.17.60"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
@@ -4279,22 +4279,6 @@
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.9.2.tgz#f755c5229f1401bbff7307d037c6e38fa169ad1d"
   integrity sha512-ryoo+EB19lMxAd80ln9BVf8pdOAxLb97amrQ3SFN9OCRn/5M5wvwDgAe4i8ZjhpbiHoDeP8yavcTEnpKBo7lZg==
 
-"@vechain/ethers@^4.0.27-5":
-  version "4.0.27-5"
-  resolved "https://registry.yarnpkg.com/@vechain/ethers/-/ethers-4.0.27-5.tgz#2e7d40294b2e14ddf4cf6f6094bbdc871e26e299"
-  integrity sha512-dR+rTUauPJpqHNBdEgV6Xh+o009uCRPCvN2HWYIAzZP2SvgsPHLxNUzeRbRKhNzz/HC8HjWNvECRxODF88B03Q==
-  dependencies:
-    "@types/node" "^10.3.2"
-    aes-js "3.0.0"
-    bn.js "^4.4.0"
-    elliptic "6.5.4"
-    hash.js "1.1.3"
-    js-sha3 "0.5.7"
-    scrypt-js "2.0.4"
-    setimmediate "1.0.4"
-    uuid "2.0.1"
-    xmlhttprequest "1.8.0"
-
 "@vechain/vebetterdao-contracts@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@vechain/vebetterdao-contracts/-/vebetterdao-contracts-4.1.0.tgz#5a081bf9c548ea777fe16dcab40536d6d2cc1a62"
@@ -4516,11 +4500,6 @@ adm-zip@^0.4.16:
   version "0.4.16"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.16.tgz#cf4c508fdffab02c269cbc7f471a875f05570365"
   integrity sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==
-
-aes-js@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
-  integrity sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==
 
 aes-js@4.0.0-beta.5:
   version "4.0.0-beta.5"
@@ -5031,7 +5010,7 @@ bn.js@4.11.6:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
   integrity sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==
 
-bn.js@^4.11.9, bn.js@^4.4.0:
+bn.js@^4.11.9:
   version "4.12.2"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.2.tgz#3d8fed6796c24e177737f7cc5172ee04ef39ec99"
   integrity sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==
@@ -6086,7 +6065,7 @@ electron-to-chromium@^1.5.173:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.177.tgz#db730d8254959184e65320a3a0b7edcd29c54f60"
   integrity sha512-7EH2G59nLsEMj97fpDuvVcYi6lwTcM1xuWw3PssD8xzboAW7zj7iB3COEEEATUfjLHrs5uKBLQT03V/8URx06g==
 
-elliptic@6.5.4, elliptic@6.6.1, elliptic@^6.5.7, elliptic@^6.6.1:
+elliptic@6.6.1, elliptic@^6.5.7, elliptic@^6.6.1:
   version "6.6.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
   integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
@@ -6857,7 +6836,7 @@ ethereumjs-util@^7.1.4:
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
 
-ethers@^5.7.2, ethers@^6.14.0, ethers@^6.9.0:
+ethers@^5.7.2, ethers@^6.13.0, ethers@^6.14.0, ethers@^6.9.0:
   version "6.14.4"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-6.14.4.tgz#0f6fbc562a8425c7c888da307fa71ef796be0c04"
   integrity sha512-Jm/dzRs2Z9iBrT6e9TvGxyb5YVKAPLlpna7hjxH7KH/++DSh2T/JVmQUv7iHI5E55hDbp/gEVvstWYXVxXFzsA==
@@ -7683,14 +7662,6 @@ hash-base@^3.0.0:
     inherits "^2.0.4"
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
-
-hash.js@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.3.tgz#340dedbe6290187151c1ea1d777a3448935df846"
-  integrity sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==
-  dependencies:
-    inherits "^2.0.3"
-    minimalistic-assert "^1.0.0"
 
 hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
   version "1.1.7"
@@ -11013,11 +10984,6 @@ scheduler@^0.23.2:
   dependencies:
     loose-envify "^1.1.0"
 
-scrypt-js@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.4.tgz#32f8c5149f0797672e551c07e230f834b6af5f16"
-  integrity sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==
-
 scrypt-js@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
@@ -11106,11 +11072,6 @@ set-proto@^1.0.0:
     dunder-proto "^1.0.1"
     es-errors "^1.3.0"
     es-object-atoms "^1.0.0"
-
-setimmediate@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.4.tgz#20e81de622d4a02588ce0c8da8973cbcf1d3138f"
-  integrity sha512-/TjEmXQVEzdod/FFskf3o7oOAsGhHf2j1dZqRFbDzq4F3mvvxflIIi4Hd3bLQE9y/CpwqfSQam5JakI/mi3Pog==
 
 setimmediate@^1.0.5:
   version "1.0.5"
@@ -11939,15 +11900,15 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-thor-devkit@^2.0.9:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/thor-devkit/-/thor-devkit-2.1.1.tgz#74d80c5c800cc5febda36220730a1c4446b91438"
-  integrity sha512-hkXCS3sUy0v6WvUBEARRRIUpVUD+0pNvYOyY05iEoyEbpTOTI1J5+h/0ixdOxM0W5lOKa55PfCtGLVOK0JaZpA==
+thor-devkit@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/thor-devkit/-/thor-devkit-2.2.0.tgz"
+  integrity sha512-Z9zNSDys84LLscxM27AFMtH3ZclfzsQxg8Jyg7u87N4HoZ6p4YSB2Zs50h+b6h/noIWQXDewll2V31mcM4dd7g==
   dependencies:
-    "@vechain/ethers" "^4.0.27-5"
     bignumber.js "^7.2.1"
     blakejs "^1.1.2"
     elliptic "^6.6.1"
+    ethers "^6.13.0"
     fast-json-stable-stringify "^2.1.0"
     js-sha3 "0.5.7"
     rlp "^2.0.0"
@@ -12640,11 +12601,6 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-uuid@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.1.tgz#c2a30dedb3e535d72ccf82e343941a50ba8533ac"
-  integrity sha512-nWg9+Oa3qD2CQzHIP4qKUqwNfzKn8P0LtFhotaCTFchsV7ZfDhAybeip/HZVeMIpZi9JgY1E3nUlwaCmZT1sEg==
-
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
@@ -13169,11 +13125,6 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
-
-xmlhttprequest@1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
-  integrity sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA==
 
 xxhash-wasm@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
## Summary

- Bump `thor-devkit` from 2.0.9 to 2.2.0
- Remove hardcoded `blockRef` from transaction body options in doc examples (no longer needed with 2.2.0)
- Increase `waitForBlock` test timeouts to reduce flaky failures on testnet
- Add null guard and optional chaining for deployment receipt in contract example
- Replace `ts-node-test` runner with custom ESM-compatible example runner (`run-examples.mjs`)
- Add error handling to VeChainProvider subscription polling: tolerate transient network errors and stop polling on unexpected failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated transaction examples to stop hardcoding blockRef, letting defaults determine it.
  * Added a script to discover and run docs examples sequentially.
  * Improved example contract checks to guard against missing receipts/outputs.
  * Updated docs test entrypoint to use the new runner.

* **Tests**
  * Increased timeouts for block integration tests and fixture cases for stability.

* **Chores**
  * Bumped thor-devkit dev dependency to v2.2.0.

* **Bug Fixes**
  * Improved subscription polling behavior and error handling to make live updates more robust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->